### PR TITLE
Fix for Fresh Element Solo (D4) provisoning and some functionality

### DIFF
--- a/addon/CHANGELOG-LOCAL.md
+++ b/addon/CHANGELOG-LOCAL.md
@@ -1,0 +1,79 @@
+# Local changes on top of upstream 1.2.0
+
+This is a local fork of https://github.com/alex-so-3/petkit-local, built to
+apply one fix ahead of it landing upstream (if it does).
+
+## dev_signup: accept identity from a form-urlencoded POST body
+
+**File:** `petkit_local/http/handlers/signup.py`
+
+**Problem:** `dev_signup` only read the device's `id` (and `mac`/`firmware`)
+from the `X-Device` header or the URL query string. Confirmed on hardware
+(PetKit Fresh Element Solo / D4, firmware 1.267) that this device sends its
+identity as a `application/x-www-form-urlencoded` POST body instead:
+
+```
+POST /6/d4/dev_signup
+Content-Type: application/x-www-form-urlencoded
+
+hardware=1&firmware=1.267&mac=c05d89d25204&timezone=2.0&locale=Europe/Amsterdam
+&id=400090690&sn=20241223G11497&bt_mac=c05d89d25206&ap_mac=c05d89d25205&chipid=13783556
+```
+
+No `X-Device` header, no query string — so `device_id(request)` always
+returned `None` and the device was rejected with `{"error": "missing device
+id"}` even though its id was right there in the body. This appears to affect
+the whole D3/D4/D4s family (ESP32-based feeders), which upstream lists as
+"supported, not tested" — this looks like the untested part.
+
+**Fix:** when the header/query resolution comes up empty *and* the request is
+form-encoded, fall back to reading `id`/`sn`/`mac`/`firmware` from the POST
+body — only for whichever fields are still missing, so a value already
+resolved from the trusted `X-Device` header is never overridden by the body.
+
+**Worth doing eventually:** open this as an issue/PR against upstream with
+the log line above — this isn't specific to this network, it should affect
+every D3/D4/D4s owner.
+
+## heartbeat: ESP32 family uses different msgType numbering than Ingenic
+
+**File:** `petkit_local/http/handlers/heartbeat.py`
+
+**Problem:** `_to_heartbeat_content` translates a queued command into the
+`{"msgType": ..., "payload": ..., "type": ..., "timestamp": ...}` shape sent
+over the HTTP heartbeat (the fallback path for any device without a live MQTT
+session — which, per the missing ESP32 TLS-bypass patcher, is every ESP32
+device today). `_SERVICE_MAP`'s numbers were only ever confirmed against T5
+(Ingenic) cloud traffic.
+
+Captured real cloud traffic for a `property/set` command (turning off the D4's
+indicator light) via proxy mode + payload capture, 2026-08-01:
+
+```json
+{"msgType": 1, "payload": {"lightMode": 0}, "timestamp": 1785621658}
+```
+
+vs. what the code sent:
+
+```json
+{"msgType": 5, "payload": {"lightMode": 0}, "type": "property_set", "timestamp": ...}
+```
+
+Wrong `msgType` (1 vs 5) and an extra `type` field the real firmware never
+sends. The D4 dispatches on `msgType`, so `5` is presumably unrecognized and
+silently dropped — command "delivered" per the log, but nothing happens on
+the device.
+
+**Fix:** added `_ESP32_SERVICE_MAP`, consulted instead of `_SERVICE_MAP` for
+non-`is_next_gen` devices (ESP32 family: T3/T4/D3/D4/D4S/W4/W5/CTW2/CTW3).
+Currently only contains the confirmed `property/set → (1, None)` entry (the
+`None` means "omit the `type` key entirely"); every other service falls back
+to `_SERVICE_MAP`'s Ingenic numbers, which are **not** confirmed correct for
+ESP32 and may need their own hardware capture (e.g. `feed_realtime` for the
+feed button, if it's still not working after this patch).
+
+**Worth doing eventually:** capture `start`/`end`/`feed_realtime`/`connect`
+against real cloud traffic too, and send the whole thing upstream as one PR
+alongside the `dev_signup` fix — same root cause (ESP32 protocol assumed to
+match Ingenic, never verified).
+

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,7 +1,7 @@
-name: "PetKit Local"
-description: "Local cloud replacement for PetKit litter boxes, feeders, fountains and accessories"
-version: "1.2.0"
-slug: "petkitlocal"
+name: "PetKit Local (local fork)"
+description: "Local cloud replacement for PetKit litter boxes, feeders, fountains and accessories - local fork with ESP32 dev_signup fix"
+version: "1.2.0-local1"
+slug: "petkitlocal_fork"
 url: "https://github.com/alex-so-3/petkit-local"
 # No `image:` key, so the Supervisor builds this on the user's own machine.
 #

--- a/addon/petkit_local/ha/commands.py
+++ b/addon/petkit_local/ha/commands.py
@@ -161,12 +161,14 @@ LITTER_ACTIONS = {
 def _feed(amount: int = 10) -> Command:
     """Dispense `amount` portions now; amount=0 cancels a pending manual feed.
 
-    The random `id` is the feed's own identifier (localkit FeedRealtime uses
-    the same `r_{date}_{nnnn}-1` shape), not the envelope id.
+    LOCAL PATCH (see CHANGELOG-LOCAL.md): the id's shape was corrected to match
+    real cloud traffic, confirmed twice on a D4 (`r_20260802_882_882-1`,
+    `r_20260802_4057_4057-1`) - the random number appears TWICE before `-1`,
+    not once as the original `r_{date}_{nnnn}-1` assumed.
     """
     return ("feed_realtime", _envelope("thing.service.feed_realtime", {
         "amount": amount,
-        "id": f"r_{time.strftime('%Y%m%d')}_{random.randint(1000, 9999)}-1",
+        "id": (lambda n: f"r_{time.strftime('%Y%m%d')}_{n}_{n}-1")(random.randint(1000, 9999)),
     }))
 
 

--- a/addon/petkit_local/http/handlers/heartbeat.py
+++ b/addon/petkit_local/http/handlers/heartbeat.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # MQTT service suffix → heartbeat msgType + type field
+# Confirmed against real T5 (Ingenic) cloud traffic. Embedded-Linux family only
+# — see _ESP32_SERVICE_MAP for the ESP32 family, which uses different numbers.
 _SERVICE_MAP = {
     "start": (2, "start"),
     "end": (3, "end"),
@@ -50,8 +52,25 @@ _SERVICE_MAP = {
     "connect": (7, "connect"),
 }
 
+# LOCAL PATCH (see CHANGELOG-LOCAL.md): the ESP32 family does not share the
+# Ingenic family's msgType numbering. Confirmed on real hardware (D4,
+# firmware 1.267, capture 2026-08-01): a property/set command from PetKit's
+# actual cloud arrived over the heartbeat as
+#   {"msgType": 1, "payload": {"lightMode": 0}, "timestamp": ...}
+# — msgType 1, not 5, and with NO "type" key at all (a `None` type_str below
+# means "omit the type field entirely" in _to_heartbeat_content).
+#
+# Only property/set is confirmed. start/end/feed_realtime/connect are NOT
+# verified for ESP32 yet — they fall back to _SERVICE_MAP's numbers below,
+# which are only known-correct for the Ingenic family and may well be wrong
+# here too. If the feed button still does nothing after this patch, that's
+# almost certainly why; it needs its own hardware capture to confirm.
+_ESP32_SERVICE_MAP = {
+    "property/set": (1, None),
+}
 
-def _to_heartbeat_content(cmd: Any) -> str:
+
+def _to_heartbeat_content(cmd: Any, is_next_gen: bool = True) -> str:
     """Convert a queued command into the heartbeat `content` string.
 
     Accepts the several shapes producers queue, in this order: an already
@@ -61,12 +80,21 @@ def _to_heartbeat_content(cmd: Any) -> str:
     is read from the `_service_suffix` marker the producer attached or, failing
     that, inferred from a substring match on its `method`.
 
+    Args:
+        is_next_gen: Which msgType numbering to use. True (default) is the
+            Ingenic/T5 family, confirmed against real cloud traffic. False is
+            the ESP32 family, which uses different numbers - see
+            _ESP32_SERVICE_MAP - and is only confirmed for property/set so far.
+
     Returns:
         A JSON string ``{"msgType": int, "payload": ..., "type": str,
-        "timestamp": int}``. An envelope for an unrecognised service falls back
-        to the `start` service (msgType 2) rather than being dropped, since a
-        command that arrives mislabelled is easier to diagnose from the device's
-        reaction than one that silently disappears.
+        "timestamp": int}`` for the Ingenic family, or the same without the
+        "type" key for the ESP32 family (confirmed: real ESP32 traffic carries
+        no "type" field at all). An envelope for an unrecognised service falls
+        back to the `start` service (msgType 2, Ingenic numbering - no ESP32
+        number is confirmed for it either) rather than being dropped, since a
+        command that arrives mislabelled is easier to diagnose from the
+        device's reaction than one that silently disappears.
     """
     if isinstance(cmd, str):
         return cmd
@@ -92,15 +120,16 @@ def _to_heartbeat_content(cmd: Any) -> str:
                 service = suffix
                 break
 
-    msg_type, type_str = _SERVICE_MAP.get(service, (2, "start"))
+    service_map = _SERVICE_MAP if is_next_gen else {**_SERVICE_MAP, **_ESP32_SERVICE_MAP}
+    msg_type, type_str = service_map.get(service, (2, "start"))
     ts = int(time.time())
 
-    return json.dumps({
-        "msgType": msg_type,
-        "payload": params,
-        "type": type_str,
-        "timestamp": ts,
-    })
+    body: dict[str, Any] = {"msgType": msg_type, "payload": params}
+    if type_str is not None:
+        body["type"] = type_str
+    body["timestamp"] = ts
+
+    return json.dumps(body)
 
 
 #: How long after a CONNECT an `iotStatus=0` is treated as a lagging sample
@@ -191,7 +220,7 @@ async def handle_heartbeat(request: web.Request) -> web.Response:
                 result.append({
                     "time": ts_ms,
                     "timestamp": ts,
-                    "content": _to_heartbeat_content(cmd),
+                    "content": _to_heartbeat_content(cmd, device.is_next_gen),
                 })
             log.info("Heartbeat %s (id=%d): delivering %d commands",
                      device.device_type, device.petkit_id, len(cmds))

--- a/addon/petkit_local/http/handlers/signup.py
+++ b/addon/petkit_local/http/handlers/signup.py
@@ -15,7 +15,7 @@ import logging
 
 from aiohttp import web
 
-from petkit_local.http.handlers._common import device_id, device_serial
+from petkit_local.http.handlers._common import device_id, device_serial, _coerce_device_id
 
 log = logging.getLogger(__name__)
 
@@ -26,6 +26,14 @@ async def handle_signup(request: web.Request) -> web.Response:
     `mac` and `firmware` are read from the query string only — they are not part
     of the `X-Device` header — and are stored as reported, since nothing else in
     the system can supply them.
+
+    LOCAL PATCH (see CHANGELOG-LOCAL.md): some ESP32-family devices (D4
+    feeder, confirmed on hardware 2026-08-01) send their identity as a
+    `www-form-urlencoded` POST body instead of the query string / X-Device
+    header the Ingenic family uses. When the header/query resolution comes up
+    empty and the request is form-encoded, the body is consulted as a
+    fallback — only for fields still missing, so a value already resolved
+    from the trusted X-Device header is never overridden by the body.
 
     Returns:
         `Device.to_signup()` for the created or existing device. The one
@@ -43,6 +51,22 @@ async def handle_signup(request: web.Request) -> web.Response:
     sn = device_serial(request)
     mac = request.query.get("mac", "")
     firmware = request.query.get("firmware", "")
+
+    if request.content_type == "application/x-www-form-urlencoded" and (
+        petkit_id is None or not sn or not mac or not firmware
+    ):
+        try:
+            form = await request.post()
+        except Exception:
+            form = {}
+        if petkit_id is None:
+            petkit_id = _coerce_device_id(form.get("id"))
+        if not sn:
+            sn = str(form.get("sn", "")).strip()
+        if not mac:
+            mac = str(form.get("mac", "")).strip()
+        if not firmware:
+            firmware = str(form.get("firmware", "")).strip()
 
     if petkit_id is None:
         return web.json_response({"error": "missing device id"}, status=400)


### PR DESCRIPTION
This is a fix that Claude Code implemented in order to provision the Fresh Element Solo (D4). At the time of implementing this fix (release 1.2.0), it could not be provisioned yet and I had to create a DNS rewrite rule to redirect from PetKit's API server to the local one from this project.

Claude also fixed some of the functionality such as turning the indicator light on/off, child lock on/off and feeder sound on/off. All other functionalities (such as feeding) did not work or were not tested. All device states were also incorrect or not reporting.