### PR TITLE
fix(feeder): extract device IP so camera feeders get a stream URL

### DIFF
--- a/addon/petkit_local/devices/state_parsers.py
+++ b/addon/petkit_local/devices/state_parsers.py
@@ -655,6 +655,19 @@ def _parse_feeder(body: dict[str, Any]) -> dict[str, Any]:
         ], parsed_fs)
         state["feedState"] = parsed_fs
 
+    # Camera feeders (D4H/D4SH) carry their LAN IP in the free-form `other`
+    # string, e.g. "...,Ip:10.50.0.10,...". The go2rtc camera probe needs
+    # state["ip"] or it never advertises a stream URL — and unlike the litter
+    # parser, this one used to drop it, so a camera feeder's stream stayed
+    # invisible. Prefer a flat Ip/ip key if a firmware ever sends one.
+    ip = body.get("Ip", body.get("ip", ""))
+    if not ip and isinstance(body.get("other"), str):
+        m = re.search(r'Ip:"?([0-9.]+)"?', body["other"])
+        if m:
+            ip = m.group(1)
+    if ip:
+        state["ip"] = ip
+
     _extract_wifi_rssi(body, state)
     return state
 


### PR DESCRIPTION
## Problem

On a camera feeder (D4H/D4SH), **Local Camera Streaming** applies and the device serves FLV, but the **Camera Stream URL sensor stays empty** and go2rtc never advertises a stream.

## Cause

The go2rtc supervisor only probes/advertises devices with `state["ip"]` set. `_parse_feeder` never sets it — only the litter-box parsers do (`body["Ip"]` / the `other` string). So a camera feeder's stream is invisible even though it's up.

## Fix

`_parse_feeder` now extracts the IP from the same free-form `other` string the litter path already reads (`"...,Ip:10.50.0.10,..."`), preferring a flat `Ip`/`ip` key if one is ever sent.

Verified on a D4H (fw 867): after this, `state["ip"]` is populated and the RTSP stream URL is advertised.