### PR TITLE
Expose bucket endpoint

### DIFF
--- a/addon/petkit_local/main.py
+++ b/addon/petkit_local/main.py
@@ -115,6 +115,9 @@ def main() -> None:
     # line.
     parser.add_argument("--web-port", type=int, default=None, help="Web panel port (default 8099)")
     parser.add_argument("--bucket-port", type=int, default=None, help="Media upload bucket port (default 9000)")
+    parser.add_argument("--bucket-endpoint", default=None,
+                        help="Media bucket base URL the device is told to use "
+                             "(default: https://<api-url host>:<bucket-port>)")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     parser.add_argument("--ha-addon", action="store_true", help="Self-configure from /data/options.json + Supervisor (HA add-on mode)")
     args = parser.parse_args()
@@ -155,6 +158,8 @@ def main() -> None:
             config.web_port = args.web_port
         if args.bucket_port is not None:
             config.bucket_port = args.bucket_port
+        if args.bucket_endpoint is not None:
+            config.bucket_endpoint = args.bucket_endpoint
         if args.debug:
             config.log_level = "DEBUG"
 

--- a/addon/tests/test_bucket_endpoint.py
+++ b/addon/tests/test_bucket_endpoint.py
@@ -6,6 +6,8 @@ add-on path had always been fine because the Supervisor hands over a host IP;
 standalone had nothing and fell back to a constant.
 """
 import json
+import subprocess
+import sys
 
 from petkit_local.config import Config
 from petkit_local.devices.base import Device
@@ -38,6 +40,17 @@ def test_an_explicit_endpoint_wins():
                bucket_endpoint="https://10.0.0.9:9000")
     c.resolve_bucket_endpoint()
     assert c.bucket_endpoint == "https://10.0.0.9:9000"
+
+
+def test_the_cli_exposes_bucket_endpoint():
+    proc = subprocess.run(
+        [sys.executable, "-m", "petkit_local.main", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert proc.returncode == 0
+    assert "--bucket-endpoint" in proc.stdout
 
 
 def test_no_api_url_leaves_it_empty_rather_than_inventing_one():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,10 @@ services:
       # host out and there is nothing to derive them from — media uploads in
       # particular then have nowhere to go, and the add-on says so at startup.
       - --api-url=http://CHANGE-ME:8080/6/
+      # Optional: override the derived https://<api-host>:9000 media upload URL.
+      # Use this when devices must upload through a different hostname, port or
+      # TLS-terminating proxy than the API host.
+      # - --bucket-endpoint=https://CHANGE-ME:9000
       - --port=8080
       - --mqtt-tls
       - --mqtt-tls-port=443


### PR DESCRIPTION
## Summary

Expose `--bucket-endpoint` for standalone Docker/Compose installs.

This lets users override the derived media upload bucket URL when the device needs to upload to a different hostname, port, or TLS-terminating proxy than the API host.

## Changes

- Add `--bucket-endpoint` CLI flag.
- Wire the flag into standalone config before `resolve_bucket_endpoint()`.
- Add a commented `docker-compose.yml` example:
  - `--bucket-endpoint=https://CHANGE-ME:9000`
- Add a CLI help regression test.

## Why

Without this flag, standalone installs derive the bucket URL from:

```text
https://<api-url host>:<bucket-port>