### PR TITLE
Support ARM opt boot patcher paths

### DIFF
--- a/addon/petkit_local/patchers/cacert.py
+++ b/addon/petkit_local/patchers/cacert.py
@@ -72,11 +72,11 @@ PATCHER_INFO = {
         "This patch appends the add-on's self-signed certificate to that bundle "
         "so uploads to our local bucket succeed.\n\n"
         "Apply this together with the Local Storage patch.\n\n"
-        "What it does: copies /app/bin/ca.crt to /system/ca_patched.crt, appends "
-        "the add-on's certificate, then updates /system/app_init.sh to "
+        "What it does: copies /app/bin/ca.crt to writable storage, appends "
+        "the add-on's certificate, then updates the boot wrapper to "
         "bind-mount the patched bundle before the stock init starts cloud."
     ),
-    "files": ["/system/ca_patched.crt"],
+    "files": ["ca_patched.crt"],
     # No architecture: this appends PEM text to a certificate bundle and
     # bind-mounts the result. Nothing here is machine code.
     "arch": None,

--- a/addon/petkit_local/patchers/cloud.py
+++ b/addon/petkit_local/patchers/cloud.py
@@ -313,11 +313,12 @@ PATCHER_INFO = {
         "Where uploads go is controlled entirely by the STS token response. "
         "Switching back to PetKit cloud requires no patch changes - just "
         "change the server configuration.\n\n"
-        "What it does: copies /app/bin/cloud to /system/cloud_patched, applies "
-        "2 byte-level patches (8 bytes total), then updates "
-        "/system/app_init.sh to bind-mount the patched binary at boot."
+        "What it does: copies /app/bin/cloud to writable storage "
+        "(/system/cloud_patched on Ingenic devices, /opt/cloud_patched on "
+        "Axera devices), applies the byte-level patches, then updates the "
+        "boot wrapper to bind-mount the patched binary at boot."
     ),
-    "files": ["/system/cloud_patched"],
+    "files": ["cloud_patched"],
     "arch": None,
     # Conservative UI figure: what to tell the user BEFORE we know the model.
     # cloud is 304,204 B on a T5 and 188,452 B on a D4SH; size-preserving.

--- a/addon/petkit_local/patchers/common.py
+++ b/addon/petkit_local/patchers/common.py
@@ -4,7 +4,7 @@
   actually using (same PATH 2 format from note 18)
 - Temporary httpd on the device for file download
 - File staging on the add-on for device wget
-- Unified /system/app_init.sh wrapper generation
+- Unified app_init.sh wrapper generation
 """
 from __future__ import annotations
 
@@ -21,7 +21,6 @@ from typing import Any
 import aiohttp
 
 from petkit_local.devices.base import Device
-
 log = logging.getLogger(__name__)
 
 DEVICE_HTTPD_PORT = 8888
@@ -31,7 +30,7 @@ DEVICE_HTTPD_PORT = 8888
 DEVICE_PROBE_PORT = 8889
 STAGE_DIR = "/tmp/petkit_patcher"
 
-#: /system/app_init.sh is ~1 KB today and every patcher rewrites it.
+#: app_init.sh is ~1 KB today and every patcher rewrites it.
 WRAPPER_RESERVE_BYTES = 4096
 #: Slack for a jffs2 erase block and its metadata. Kept small deliberately:
 #: jffs2 compresses on write, so `df` UNDER-reports what will actually fit and
@@ -42,10 +41,80 @@ SPACE_MARGIN_BYTES = 65536
 class InsufficientDeviceSpace(RuntimeError):
     """Not enough free space on the device for a patch that was about to write."""
 
-# Patched files live in /system (writable jffs2, survives OTA).
-# The unified /system/app_init.sh wrapper does bind-mounts before sourcing
-# the stock /app/script/app_init.sh, so patched binaries are loaded at boot.
+# Patched files live in the writable boot override area. Ingenic boards use
+# /system; Axera ARM boards use /opt. Codename cannot decide this because D4SH
+# ships with both board families under the same type string, so patcher runs
+# probe the device filesystem before choosing.
 APP_INIT_WRAPPER = "/system/app_init.sh"
+OPT_APP_INIT_WRAPPER = "/opt/app_init.sh"
+PATCH_STORAGE_CONFIG_KEY = "patch_storage_dir"
+
+
+def set_patch_storage_dir(device: Device, storage_dir: str) -> None:
+    """Remember the probed writable patch storage directory for this device."""
+    if storage_dir not in ("/system", "/opt"):
+        raise ValueError(f"unsupported patch storage directory: {storage_dir}")
+    device.config[PATCH_STORAGE_CONFIG_KEY] = storage_dir
+
+
+async def detect_patch_storage_dir(device: Device, device_ip: str, *,
+                                   bridge: Any = None,
+                                   timeout: float = 60.0) -> str:
+    """Detect whether patches should persist under /system or /opt.
+
+    The persistent app storage carries user.conf: Ingenic exposes it under
+    /system/user.conf, while Axera exposes it under /opt/user.conf. Do not fall
+    back to codename guesses here: D4SH may be either MIPS/Ingenic or ARM/Axera.
+    """
+    command = (
+        "[ -f /system/user.conf ] && echo STORAGE /system; "
+        "[ -f /opt/user.conf ] && echo STORAGE /opt"
+    )
+    text = await run_cmd_capture(device, device_ip, command, bridge=bridge,
+                                 timeout=timeout)
+    for storage_dir in ("/system", "/opt"):
+        if f"STORAGE {storage_dir}" in (text or ""):
+            set_patch_storage_dir(device, storage_dir)
+            return storage_dir
+
+    raise RuntimeError(
+        f"could not determine writable patch storage for device {device.petkit_id}: "
+        "neither /system/user.conf nor /opt/user.conf exists")
+
+
+def uses_opt_boot(device: Device | None) -> bool:
+    """Whether this device uses the Axera-style /opt app storage."""
+    if device is not None:
+        storage_dir = device.config.get(PATCH_STORAGE_CONFIG_KEY)
+        if storage_dir in ("/system", "/opt"):
+            return storage_dir == "/opt"
+    return False
+
+
+def app_init_wrapper_path(device: Device | None = None) -> str:
+    return OPT_APP_INIT_WRAPPER if uses_opt_boot(device) else APP_INIT_WRAPPER
+
+
+def patch_storage_dir(device: Device | None = None) -> str:
+    return "/opt" if uses_opt_boot(device) else "/system"
+
+
+def patched_file_path(filename: str, device: Device | None = None) -> str:
+    return f"{patch_storage_dir(device)}/{filename}"
+
+
+def patcher_device_files(pinfo: dict[str, Any],
+                         device: Device | None = None) -> list[str]:
+    """Absolute on-device paths for a patcher's declared files.
+
+    Binary/cert patchers declare bare names because their storage directory is
+    model-dependent: /system on Ingenic, /opt on Axera. Absolute paths are passed
+    through as a defensive guard for future patchers with fixed locations.
+    """
+    result: list[str] = []
+    for name in pinfo["files"]:
+        result.append(name if name.startswith("/") else patched_file_path(name, device))
+    return result
 
 
 def build_run_cmd(command: str) -> str:
@@ -382,9 +451,9 @@ def md5hex(data: bytes) -> str:
 # This avoids the test_case_* timing problem (test_case hooks run AFTER
 # processes are already loaded into memory).
 
-WRAPPER_HEADER = """\
+WRAPPER_HEADER_TEMPLATE = """\
 #!/bin/sh
-# /system/app_init.sh - petkit-local patcher wrapper
+# {wrapper} - petkit-local patcher wrapper
 # Auto-generated. Bind-mounts patched files before running the stock init.
 """
 
@@ -394,7 +463,9 @@ WRAPPER_FOOTER = """\
 . /app/script/app_init.sh
 """
 
-# Per-patcher bind-mount blocks. Each is a tuple (patcher_id, shell_lines).
+# Per-patcher bind-mount blocks. Each block is formatted with `store`; write
+# literal shell braces as `{{` and `}}`.
+# Each is a tuple (patcher_id, shell_lines).
 # Only active patchers are included in the generated wrapper.
 #
 # /app/bin/watchdog supervises media, cloud, agora and logUpload. Its liveness
@@ -413,18 +484,18 @@ WRAPPER_FOOTER = """\
 # Hence camera bind-mounts the real tserver binary over agora rather than a
 # placeholder: exec'ing ./agora starts the local streamer, the lsof check
 # passes, and the watchdog now supervises tserver for us.
-BIND_MOUNT_BLOCKS = {
+BIND_MOUNT_TEMPLATES = {
     "mqtt": (
         "# MQTT TLS bypass: patched ctrl accepts any broker certificate\n"
-        "mount --bind /system/ctrl_patched /app/bin/ctrl\n"
+        "mount --bind {store}/ctrl_patched /app/bin/ctrl\n"
     ),
     "cloud": (
         "# Local storage: patched cloud accepts LAN IPs + skips TLS verify\n"
-        "mount --bind /system/cloud_patched /app/bin/cloud\n"
+        "mount --bind {store}/cloud_patched /app/bin/cloud\n"
     ),
     "cacert": (
         "# CA cert: cloud trusts our self-signed bucket certificate\n"
-        "mount --bind /system/ca_patched.crt /app/bin/ca.crt\n"
+        "mount --bind {store}/ca_patched.crt /app/bin/ca.crt\n"
     ),
     "camera": (
         "# Local camera: stock app_start.sh runs ./agora, which is tserver now\n"
@@ -439,13 +510,14 @@ PRE_INIT_BLOCKS = {
     "ssh": (
         "# Persistent SSH (dropbear on port 22)\n"
         "mkdir -p /tmp/.ssh\n"
-        "cp /system/authorized_keys /tmp/.ssh/authorized_keys\n"
-        "/system/dropbear -r /system/dbkey_ecdsa -p 22 &\n"
+        "cp {store}/authorized_keys /tmp/.ssh/authorized_keys\n"
+        "{store}/dropbear -r {store}/dbkey_ecdsa -p 22 &\n"
     ),
 }
 
-def generate_app_init_wrapper(active_patchers: set[str]) -> str:
-    """Generate the /system/app_init.sh wrapper for the given set of active
+def generate_app_init_wrapper(active_patchers: set[str],
+                              device: Device | None = None) -> str:
+    """Generate the app_init.sh wrapper for the given set of active
     patchers. Returns the shell script content.
 
     Everything happens before the stock init is sourced, because the stock
@@ -454,25 +526,29 @@ def generate_app_init_wrapper(active_patchers: set[str]) -> str:
     phase — camera used to start tserver there, and now reaches it through the
     agora bind-mount instead, which also puts it under the watchdog.
     """
-    lines = [WRAPPER_HEADER]
+    lines = [WRAPPER_HEADER_TEMPLATE.format(
+        wrapper=app_init_wrapper_path(device))]
+    store = patch_storage_dir(device)
     # Pre-init: things that must run before stock init (SSH, etc.)
     for pid in ("ssh",):
         if pid in active_patchers and pid in PRE_INIT_BLOCKS:
-            lines.append(PRE_INIT_BLOCKS[pid])
+            lines.append(PRE_INIT_BLOCKS[pid].format(store=store))
     for pid in ("mqtt", "cloud", "cacert", "camera"):
-        if pid in active_patchers and pid in BIND_MOUNT_BLOCKS:
-            lines.append(BIND_MOUNT_BLOCKS[pid])
+        if pid in active_patchers and pid in BIND_MOUNT_TEMPLATES:
+            lines.append(BIND_MOUNT_TEMPLATES[pid].format(store=store))
     lines.append(WRAPPER_FOOTER)
     return "".join(lines)
 
 
-def build_wrapper_upload_cmd(active_patchers: set[str]) -> str:
-    """Build a shell command that writes /system/app_init.sh on the device."""
-    content = generate_app_init_wrapper(active_patchers)
+def build_wrapper_upload_cmd(active_patchers: set[str],
+                             device: Device | None = None) -> str:
+    """Build a shell command that writes the boot wrapper on the device."""
+    wrapper = app_init_wrapper_path(device)
+    content = generate_app_init_wrapper(active_patchers, device)
     escaped = content.replace("'", "'\\''")
-    return f"printf '{escaped}' > {APP_INIT_WRAPPER} && chmod +x {APP_INIT_WRAPPER}"
+    return f"printf '{escaped}' > {wrapper} && chmod +x {wrapper}"
 
 
-def build_wrapper_remove_cmd() -> str:
+def build_wrapper_remove_cmd(device: Device | None = None) -> str:
     """Shell command to remove the wrapper (reverts to stock init on next boot)."""
-    return f"rm -f {APP_INIT_WRAPPER}"
+    return f"rm -f {app_init_wrapper_path(device)}"

--- a/addon/petkit_local/patchers/mqtt.py
+++ b/addon/petkit_local/patchers/mqtt.py
@@ -192,7 +192,7 @@ def find_offset(data: bytes) -> int:
 def patch_ctrl(data: bytes) -> tuple[bytes, int]:
     """Patch the ctrl binary. Returns (patched_data, offset).
 
-    Works on both MIPS (Ingenic T5/T6/T7/D4H/D4SH) and ARM (W7H) binaries.
+    Works on both MIPS (Ingenic) and ARM (Axera) binaries.
     The architecture is detected from the ELF header, and the right patch
     bytes and search strategy are chosen automatically.
 
@@ -240,14 +240,14 @@ PATCHER_INFO = {
         "This allows the device to connect to petkit-local's embedded MQTT "
         "broker over TLS, enabling real-time commands and event streaming "
         "instead of the slower HTTP heartbeat polling.\n\n"
-        "Works on both MIPS (Ingenic) and ARM (W7H) devices — the right "
+        "Works on both MIPS (Ingenic) and ARM (Axera) devices — the right "
         "patch is chosen from the binary itself.\n\n"
-        "What it does: copies /app/bin/ctrl to /system/ctrl_patched, patches "
+        "What it does: copies /app/bin/ctrl to writable storage, patches "
         "the x509 certificate chain verification function (16 bytes on MIPS, "
-        "8 bytes on ARM), then updates /system/app_init.sh to bind-mount the "
+        "8 bytes on ARM), then updates the boot wrapper to bind-mount the "
         "patched binary before the stock init starts ctrl."
     ),
-    "files": ["/system/ctrl_patched"],
+    "files": ["ctrl_patched"],
     "arch": None,
     # Conservative UI figure: what to tell the user BEFORE we know the model.
     # ctrl is 1,420,656 B on a T5 and 903,148 B on a D4SH; the patch

--- a/addon/petkit_local/patchers/ssh.py
+++ b/addon/petkit_local/patchers/ssh.py
@@ -1,13 +1,13 @@
 """Persistent SSH access patcher.
 
-Installs dropbear on port 22 with public-key authentication, using the
-/system/app_init.sh boot hook shared with the other patchers. Dropbear starts
-before the stock init, survives reboots and app OTA.
+Installs dropbear on port 22 with public-key authentication, using the boot
+hook shared with the other patchers. Dropbear starts before the stock init,
+survives reboots and app OTA.
 
 Unlike the binary patchers (mqtt, cloud, cacert), this one needs user input:
 a public key. The panel accepts it at apply time, stores it on
-`device.config["ssh_pubkey"]`, and writes it to `/system/authorized_keys` on
-the device. Password auth is disabled.
+`device.config["ssh_pubkey"]`, and writes it to persistent app storage on the
+device. Password auth is disabled.
 
 Two pre-built dropbear binaries are shipped — one per CPU family:
   dropbear-mipsel  165 KB  Ingenic MIPS32r2 LE (T5, T6, T7, D4H, D4SH)
@@ -23,15 +23,21 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import TYPE_CHECKING
+
+from petkit_local.patchers.common import patched_file_path
+
+if TYPE_CHECKING:
+    from petkit_local.devices.base import Device
 
 log = logging.getLogger(__name__)
 
-DROPBEAR_PATH = "/system/dropbear"
-DBKEY_PATH = "/system/dbkey_ecdsa"
-AUTHKEYS_PATH = "/system/authorized_keys"
 DBKEY_RESERVE_BYTES = 4096
-TEST_CASE_ROOT = "/system/test_case_root"
-TEST_CASE_ROOT_OLD = "/system/old_test_case_root"
+DROPBEAR_NAME = "dropbear"
+DBKEY_NAME = "dbkey_ecdsa"
+AUTHKEYS_NAME = "authorized_keys"
+TEST_CASE_ROOT_NAME = "test_case_root"
+TEST_CASE_ROOT_OLD_NAME = "old_test_case_root"
 
 _BIN_DIR = os.path.join(os.path.dirname(__file__), "..", "web", "static", "bin")
 
@@ -57,13 +63,13 @@ PATCHER_INFO = {
     "name": "Persistent SSH Access",
     "description": (
         "Installs Dropbear SSH on port 22 with public key authentication. "
-        "Uses the /system/app_init.sh boot hook for persistence — SSH starts "
+        "Uses the device boot wrapper for persistence — SSH starts "
         "before any PetKit processes and survives reboots, app OTA updates, and "
-        "factory resets (as long as /system is not formatted).\n\n"
+        "factory resets (as long as writable app storage is not formatted).\n\n"
         "A static build is shipped for each CPU family (MIPS and ARM), so this "
         "works on every Linux-based PetKit model. ECDSA host key, RSA/ECDSA "
         "pubkey auth, password auth disabled. The host key is generated once "
-        "at install and kept on /system, so the fingerprint stays the same "
+        "at install and kept in writable app storage, so the fingerprint stays the same "
         "across reboots.\n\n"
         "Requires a public key — paste one in the field below before applying. "
         "The key is stored per device and reused on re-apply.\n\n"
@@ -71,7 +77,7 @@ PATCHER_INFO = {
         "renamed to old_test_case_root (outside the test_case_* glob) to avoid "
         "running two SSH servers on port 22."
     ),
-    "files": [DROPBEAR_PATH, DBKEY_PATH, AUTHKEYS_PATH],
+    "files": [DROPBEAR_NAME, DBKEY_NAME, AUTHKEYS_NAME],
     "arch": None,
     "needs_bytes": 262144,
     "needs_pubkey": True,
@@ -81,7 +87,8 @@ PATCHER_INFO = {
 AUTHKEYS_STAGED_NAME = "authorized_keys"
 
 
-def build_install_commands(download_base: str, bin_name: str = DROPBEAR_BIN_NAME) -> list[str]:
+def build_install_commands(download_base: str, bin_name: str = DROPBEAR_BIN_NAME,
+                           device: "Device | None" = None) -> list[str]:
     """Shell commands to install dropbear on the device.
 
     Each is queued as a separate run_cmd and waited on individually, because
@@ -96,34 +103,38 @@ def build_install_commands(download_base: str, bin_name: str = DROPBEAR_BIN_NAME
     fetched with wget, exactly like the dropbear binary — the one path that is
     proven to deliver bytes unchanged.
 
-    The host key IS pre-generated and stored on `/system` so it survives every
-    reboot. Without this, `-R` writes to `/tmp` (its default), `/tmp` is wiped
-    on reboot, and the key changes every boot — which means every reboot prints
-    `REMOTE HOST IDENTIFICATION HAS CHANGED` on the client. The generation
-    uses the multi-call trick: `cp dropbear /tmp/dropbearkey` then invoke it,
-    because this busybox has `cp` but not `ln`.
+    The host key IS pre-generated and stored on writable app storage so it
+    survives every reboot. Without this, `-R` writes to `/tmp` (its default),
+    `/tmp` is wiped on reboot, and the key changes every boot — which means
+    every reboot prints `REMOTE HOST IDENTIFICATION HAS CHANGED` on the client.
+    The generation uses the multi-call trick: `cp dropbear /tmp/dropbearkey`
+    then invoke it, because this busybox has `cp` but not `ln`.
     """
+    dropbear = patched_file_path(DROPBEAR_NAME, device)
+    authkeys = patched_file_path(AUTHKEYS_NAME, device)
+    dbkey = patched_file_path(DBKEY_NAME, device)
+    test_case_root = patched_file_path(TEST_CASE_ROOT_NAME, device)
+    test_case_root_old = patched_file_path(TEST_CASE_ROOT_OLD_NAME, device)
+
     return [
         # 1. Rename an existing test_case_root out of the glob.
-        f'[ -f {TEST_CASE_ROOT} ] && mv {TEST_CASE_ROOT} {TEST_CASE_ROOT_OLD} || true',
+        f'[ -f {test_case_root} ] && mv {test_case_root} {test_case_root_old} || true',
 
         # 2. Download the dropbear binary.
-        f'wget -q -O {DROPBEAR_PATH} "{download_base}/{bin_name}" '
-        f'&& chmod +x {DROPBEAR_PATH}',
+        f'wget -q -O {dropbear} "{download_base}/{bin_name}" '
+        f'&& chmod +x {dropbear}',
 
         # 3. Download authorized_keys (staged from the stored pubkey).
-        f'wget -q -O {AUTHKEYS_PATH} "{download_base}/{AUTHKEYS_STAGED_NAME}"',
+        f'wget -q -O {authkeys} "{download_base}/{AUTHKEYS_STAGED_NAME}"',
 
         # 4. Generate a persistent host key if one does not already exist.
-        #    Stored on /system so it survives reboots — without this the key
-        #    lives in /tmp, changes every boot, and the SSH client screams.
-        f'[ -f {DBKEY_PATH} ] || '
-        f'(cp {DROPBEAR_PATH} /tmp/dropbearkey '
-        f'&& /tmp/dropbearkey -t ecdsa -f {DBKEY_PATH} '
+        f'[ -f {dbkey} ] || '
+        f'(cp {dropbear} /tmp/dropbearkey '
+        f'&& /tmp/dropbearkey -t ecdsa -f {dbkey} '
         f'&& rm -f /tmp/dropbearkey)',
 
         # 5. Start dropbear now (immediate access, before the next reboot).
         f'mkdir -p /tmp/.ssh '
-        f'&& cp {AUTHKEYS_PATH} /tmp/.ssh/authorized_keys '
-        f'&& {DROPBEAR_PATH} -r {DBKEY_PATH} -p 22 &',
+        f'&& cp {authkeys} /tmp/.ssh/authorized_keys '
+        f'&& {dropbear} -r {dbkey} -p 22 &',
     ]

--- a/addon/petkit_local/web/panel.py
+++ b/addon/petkit_local/web/panel.py
@@ -79,15 +79,16 @@ from petkit_local.media.go2rtc import stream_urls_with_rtsp
 from petkit_local.patchers.camera import PATCHER_INFO as CAMERA_PATCHER
 from petkit_local.patchers.cloud import PATCHER_INFO as CLOUD_PATCHER, patch_cloud
 from petkit_local.patchers.common import (
-    APP_INIT_WRAPPER, DEVICE_HTTPD_PORT, build_wrapper_remove_cmd, cleanup_staged, download_from_device, ensure_space_for, generate_app_init_wrapper,
-    md5hex, send_run_cmd, stage_file, wait_for_heartbeat,
+    DEVICE_HTTPD_PORT, app_init_wrapper_path, build_wrapper_remove_cmd,
+    cleanup_staged, detect_patch_storage_dir, download_from_device,
+    ensure_space_for, generate_app_init_wrapper, md5hex, patched_file_path,
+    patcher_device_files, send_run_cmd, stage_file, wait_for_heartbeat,
 )
 from petkit_local.patchers.mqtt import PATCHER_INFO as MQTT_PATCHER, patch_ctrl
 from petkit_local.patchers.ssh import (
     PATCHER_INFO as SSH_PATCHER, build_install_commands as ssh_install_commands,
     ARCH_TO_BINARY as SSH_ARCH_TO_BINARY,
-    AUTHKEYS_PATH, DBKEY_PATH, DBKEY_RESERVE_BYTES,
-    DROPBEAR_PATH, dropbear_path_for,
+    DBKEY_RESERVE_BYTES, dropbear_path_for,
 )
 from petkit_local.patchers.verify import assert_download_plausible, elf_arch
 from petkit_local.utils.coerce import to_int
@@ -2103,7 +2104,6 @@ async def api_patcher_apply(request: web.Request) -> web.Response:
     action = body.get("action", "apply")
     if patcher_id not in ALL_PATCHERS:
         return web.json_response({"error": f"unknown patcher: {patcher_id}"}, status=400)
-
     # SSH needs a public key. Accept it in the request, persist it on the device
     # config so a re-apply after an OTA does not ask again, and validate it
     # before spawning a background task that would fail minutes later.
@@ -2147,7 +2147,8 @@ async def api_patcher_apply(request: web.Request) -> web.Response:
                             f"[{patcher_id}] waiting for the running patcher to finish...")
             async with lock:
                 if action == "remove":
-                    await _patcher_remove(d, patcher_id, download_base, hub, request.app)
+                    await _patcher_remove(d, patcher_id, device_ip, download_base,
+                                          hub, request.app)
                 else:
                     await _patcher_apply(d, patcher_id, device_ip, download_base, hub, request.app)
         except asyncio.CancelledError:
@@ -2200,6 +2201,9 @@ async def _patcher_apply(d: Device, patcher_id: str, device_ip: str, download_ba
     cfg = app.get("cfg", {})
     data_dir = cfg.get("data_dir", "/data") if "data_dir" in cfg else "/data"
     P = f"[{patcher_id}]"
+    storage_dir = await detect_patch_storage_dir(d, device_ip, bridge=bridge)
+    reg.save()
+    wrapper_path = app_init_wrapper_path(d)
 
     if patcher_id in ("mqtt", "cloud", "cacert"):
         hub.publish("patcher", did, f"{P} starting temp httpd on device...")
@@ -2215,7 +2219,7 @@ async def _patcher_apply(d: Device, patcher_id: str, device_ip: str, download_ba
                 patched, offset = patch_ctrl(binary)
                 hub.publish("patcher", did, f"{P} patched at offset 0x{offset:x} (md5={md5hex(patched)[:12]})")
                 staged_name = "ctrl_patched"
-                device_path = "/system/ctrl_patched"
+                device_path = patched_file_path(staged_name, d)
             elif patcher_id == "cloud":
                 hub.publish("patcher", did, f"{P} downloading cloud from device...")
                 binary = await download_from_device(device_ip, "cloud")
@@ -2225,7 +2229,7 @@ async def _patcher_apply(d: Device, patcher_id: str, device_ip: str, download_ba
                 names = ", ".join(a["name"] for a in applied if a["status"] == "applied")
                 hub.publish("patcher", did, f"{P} applied {len(applied)} patches: {names}")
                 staged_name = "cloud_patched"
-                device_path = "/system/cloud_patched"
+                device_path = patched_file_path(staged_name, d)
             else:
                 hub.publish("patcher", did, f"{P} downloading ca.crt from device...")
                 ca_data = await download_from_device(device_ip, "ca.crt")
@@ -2235,7 +2239,7 @@ async def _patcher_apply(d: Device, patcher_id: str, device_ip: str, download_ba
                 patched = patch_ca_bundle(ca_data, our_cert)
                 hub.publish("patcher", did, f"{P} appended our cert ({len(patched)} bytes)")
                 staged_name = "ca_patched.crt"
-                device_path = "/system/ca_patched.crt"
+                device_path = patched_file_path(staged_name, d)
         finally:
             # The space probe starts its OWN httpd on a different port, and
             # `killall httpd` cannot target one — so the download server has to
@@ -2248,7 +2252,8 @@ async def _patcher_apply(d: Device, patcher_id: str, device_ip: str, download_ba
         hub.publish("patcher", did, f"{P} checking free space on device...")
         hub.publish("patcher", did, f"{P} " + await ensure_space_for(
             d, device_ip, write_bytes=len(patched),
-            targets=[device_path, APP_INIT_WRAPPER], bridge=bridge))
+            targets=[device_path, wrapper_path], bridge=bridge,
+            mount=storage_dir))
 
         stage_file(staged_name, patched)
         hub.publish("patcher", did, f"{P} uploading {staged_name} to device...")
@@ -2290,17 +2295,18 @@ async def _patcher_apply(d: Device, patcher_id: str, device_ip: str, download_ba
 
         from petkit_local.patchers.ssh import AUTHKEYS_STAGED_NAME
         authkeys = (pubkey.strip() + "\n").encode()
+        ssh_paths = patcher_device_files(SSH_PATCHER, d)
         hub.publish("patcher", did, f"{P} checking free space on device...")
         hub.publish("patcher", did, f"{P} " + await ensure_space_for(
             d, device_ip, write_bytes=len(dropbear) + len(authkeys) + DBKEY_RESERVE_BYTES,
-            targets=[DROPBEAR_PATH, AUTHKEYS_PATH, DBKEY_PATH, APP_INIT_WRAPPER],
-            bridge=bridge))
+            targets=[*ssh_paths, wrapper_path],
+            bridge=bridge, mount=storage_dir))
 
         stage_file(bin_name, dropbear)
         stage_file(AUTHKEYS_STAGED_NAME, authkeys)
         hub.publish("patcher", did, f"{P} staged {bin_name} + authorized_keys for download")
 
-        cmds = ssh_install_commands(download_base, bin_name)
+        cmds = ssh_install_commands(download_base, bin_name, d)
         for i, cmd in enumerate(cmds, 1):
             hub.publish("patcher", did, f"{P} step {i}/{len(cmds)}: {cmd[:80]}...")
             await send_run_cmd(d, cmd, bridge)
@@ -2314,23 +2320,24 @@ async def _patcher_apply(d: Device, patcher_id: str, device_ip: str, download_ba
 
     else:
         # camera writes no file of its own — but the wrapper below is still a
-        # write to /system, and a full /system is exactly why that would fail
-        # silently, leaving the patch marked active but never taking effect.
+        # write to persistent storage, and a full filesystem is exactly why
+        # that would fail silently, leaving the patch marked active but inert.
         hub.publish("patcher", did, f"{P} checking free space on device...")
         hub.publish("patcher", did, f"{P} " + await ensure_space_for(
-            d, device_ip, write_bytes=0, targets=[APP_INIT_WRAPPER], bridge=bridge))
+            d, device_ip, write_bytes=0, targets=[wrapper_path], bridge=bridge,
+            mount=storage_dir))
 
     active = _get_active_patchers(d)
     active.add(patcher_id)
     _save_active_patchers(d, active, reg)
 
-    hub.publish("patcher", did, f"{P} uploading /system/app_init.sh wrapper...")
-    wrapper_content = generate_app_init_wrapper(active)
+    hub.publish("patcher", did, f"{P} uploading {wrapper_path} wrapper...")
+    wrapper_content = generate_app_init_wrapper(active, d)
     stage_file("app_init.sh", wrapper_content.encode())
     await send_run_cmd(
         d,
-        f"wget -q -O {APP_INIT_WRAPPER} {download_base}/app_init.sh && "
-        f"chmod +x {APP_INIT_WRAPPER}",
+        f"wget -q -O {wrapper_path} {download_base}/app_init.sh && "
+        f"chmod +x {wrapper_path}",
         bridge,
     )
     # Wait for the device to actually fetch the file BEFORE cleaning it up.
@@ -2349,7 +2356,7 @@ async def _patcher_apply(d: Device, patcher_id: str, device_ip: str, download_ba
     hub.publish("patcher", did, f"{P} done - device will reboot, patch active on next boot")
 
 
-async def _patcher_remove(d: Device, patcher_id: str, download_base: str,
+async def _patcher_remove(d: Device, patcher_id: str, device_ip: str, download_base: str,
                           hub: EventHub, app: web.Application) -> None:
     """Drop one patcher from the active set and reboot the device into it.
 
@@ -2362,6 +2369,9 @@ async def _patcher_remove(d: Device, patcher_id: str, download_base: str,
     reg = app["registry"]
     bridge = app.get("bridge")  # see _patcher_apply
     P = f"[{patcher_id}]"
+    await detect_patch_storage_dir(d, device_ip, bridge=bridge)
+    reg.save()
+    wrapper_path = app_init_wrapper_path(d)
 
     active = _get_active_patchers(d)
     active.discard(patcher_id)
@@ -2371,12 +2381,13 @@ async def _patcher_remove(d: Device, patcher_id: str, download_base: str,
     # A pure bind-mount patcher (camera) puts no file on the device, and
     # busybox `rm -f` with no operands prints its usage and exits non-zero —
     # which would be a confusing failure for a step that has nothing to do.
-    files = " ".join(pinfo["files"])
+    file_paths = patcher_device_files(pinfo, d)
+    files = " ".join(file_paths)
     cleanup_cmds = f"rm -f {files}" if files else "true"
 
     if active:
         hub.publish("patcher", did, f"{P} uploading updated wrapper...")
-        wrapper_content = generate_app_init_wrapper(active)
+        wrapper_content = generate_app_init_wrapper(active, d)
         stage_file("app_init.sh", wrapper_content.encode())
         # Delete the patched files and download the new wrapper in one command,
         # so the device never boots with a wrapper that references files that
@@ -2384,8 +2395,8 @@ async def _patcher_remove(d: Device, patcher_id: str, download_base: str,
         await send_run_cmd(
             d,
             f"{cleanup_cmds}; "
-            f"wget -q -O {APP_INIT_WRAPPER} {download_base}/app_init.sh && "
-            f"chmod +x {APP_INIT_WRAPPER}",
+            f"wget -q -O {wrapper_path} {download_base}/app_init.sh && "
+            f"chmod +x {wrapper_path}",
             bridge,
         )
         # Same wait-then-cleanup as apply: the staged file must survive until
@@ -2398,7 +2409,9 @@ async def _patcher_remove(d: Device, patcher_id: str, download_base: str,
         hub.publish("patcher", did, f"{P} rebooting device...")
         await send_run_cmd(d, "reboot", bridge)
     else:
-        await send_run_cmd(d, f"{cleanup_cmds}; {build_wrapper_remove_cmd()} && reboot", bridge)
+        await send_run_cmd(
+            d, f"{cleanup_cmds}; {build_wrapper_remove_cmd(d)} && reboot",
+            bridge)
 
     hub.publish("patcher", did, f"{P} removal queued - device will reboot")
 

--- a/addon/petkit_local/web/static/bin/README.md
+++ b/addon/petkit_local/web/static/bin/README.md
@@ -4,7 +4,8 @@
 
 The SSH daemon the `ssh` patcher installs onto a rooted PetKit device
 (`petkit_local/patchers/ssh.py`). It is served to the device over the patcher
-download path and written to `/system/dropbear`.
+download path and written to persistent app storage (`/system/dropbear` on
+Ingenic devices, `/opt/dropbear` on Axera devices).
 
 | | mipsel | armv7 |
 |---|---|---|
@@ -41,7 +42,7 @@ SHA-256 of each output. Takes about two minutes on a modest x86_64 host.
 
 Root's home is `/` (read-only squashfs), so `~/.ssh/` does not exist and
 cannot be created. `/tmp/.ssh/` is writable (tmpfs). The patcher's boot hook
-copies `/system/authorized_keys` there at startup.
+copies the persistent `authorized_keys` there at startup.
 
 ### 2. Buffer size fix
 
@@ -75,7 +76,7 @@ The device's `/etc/shadow` has a DES crypt hash. DES is deprecated and musl's
 ```
 
 Fallback paths only — the patcher starts dropbear with
-`-r /system/dbkey_ecdsa`, which is persistent across reboots.
+`-r <persistent-storage>/dbkey_ecdsa`, which is persistent across reboots.
 
 ## Build configuration
 

--- a/addon/tests/test_patchers.py
+++ b/addon/tests/test_patchers.py
@@ -1,5 +1,5 @@
 """Tests for petkit_local/patchers/common.py — run_cmd queueing, file staging,
-and the unified /system/app_init.sh wrapper generator."""
+and the unified app_init.sh wrapper generator."""
 import json
 import os
 
@@ -14,8 +14,15 @@ from petkit_local.patchers.common import (
     generate_app_init_wrapper,
     build_wrapper_upload_cmd,
     build_wrapper_remove_cmd,
+    detect_patch_storage_dir,
     APP_INIT_WRAPPER,
+    OPT_APP_INIT_WRAPPER,
+    app_init_wrapper_path,
+    patched_file_path,
+    patcher_device_files,
+    set_patch_storage_dir,
 )
+from petkit_local.patchers.ssh import build_install_commands
 
 
 # --- run_cmd delivery ---
@@ -223,6 +230,111 @@ def test_wrapper_unknown_patcher_ignored():
     assert "bogus" not in w
 
 
+def test_axera_wrapper_uses_opt_storage():
+    d = Device(device_type="d4sh", petkit_id=7)
+    set_patch_storage_dir(d, "/opt")
+    w = generate_app_init_wrapper({"cloud", "cacert"}, d)
+    assert "mount --bind /opt/cloud_patched /app/bin/cloud" in w
+    assert "mount --bind /opt/ca_patched.crt /app/bin/ca.crt" in w
+    assert "/system/cloud_patched" not in w
+    assert ". /app/script/app_init.sh" in w
+
+
+def test_axera_paths_use_opt_boot_override():
+    axera = Device(device_type="d4sh", petkit_id=7)
+    set_patch_storage_dir(axera, "/opt")
+    ing = Device(device_type="d4sh", petkit_id=8)
+    set_patch_storage_dir(ing, "/system")
+    assert app_init_wrapper_path(axera) == OPT_APP_INIT_WRAPPER
+    assert patched_file_path("cloud_patched", axera) == "/opt/cloud_patched"
+    assert app_init_wrapper_path(ing) == APP_INIT_WRAPPER
+    assert patched_file_path("cloud_patched", ing) == "/system/cloud_patched"
+    assert app_init_wrapper_path() == APP_INIT_WRAPPER
+    assert patched_file_path("cloud_patched") == "/system/cloud_patched"
+
+
+async def test_user_conf_probe_prefers_system_when_present(monkeypatch):
+    d = Device(device_type="t5", petkit_id=1)
+
+    async def fake_run_cmd_capture(device, device_ip, command, **kwargs):
+        assert "/system/user.conf" in command
+        assert "/opt/user.conf" in command
+        return "STORAGE /system\nSTORAGE /opt\n"
+
+    monkeypatch.setattr("petkit_local.patchers.common.run_cmd_capture", fake_run_cmd_capture)
+    assert await detect_patch_storage_dir(d, "127.0.0.1") == "/system"
+    assert app_init_wrapper_path(d) == APP_INIT_WRAPPER
+
+
+async def test_user_conf_probe_uses_opt_when_system_is_absent(monkeypatch):
+    d = Device(device_type="d4sh", petkit_id=1)
+
+    async def fake_run_cmd_capture(device, device_ip, command, **kwargs):
+        assert "/system/user.conf" in command
+        assert "/opt/user.conf" in command
+        return "STORAGE /opt\n"
+
+    monkeypatch.setattr("petkit_local.patchers.common.run_cmd_capture", fake_run_cmd_capture)
+    assert await detect_patch_storage_dir(d, "127.0.0.1") == "/opt"
+    assert app_init_wrapper_path(d) == OPT_APP_INIT_WRAPPER
+
+
+async def test_user_conf_probe_refuses_to_guess(monkeypatch):
+    d = Device(device_type="d4sh", petkit_id=1)
+
+    async def fake_run_cmd_capture(device, device_ip, command, **kwargs):
+        return ""
+
+    monkeypatch.setattr("petkit_local.patchers.common.run_cmd_capture", fake_run_cmd_capture)
+    try:
+        await detect_patch_storage_dir(d, "127.0.0.1")
+    except RuntimeError as e:
+        assert "neither /system/user.conf nor /opt/user.conf exists" in str(e)
+    else:
+        raise AssertionError("expected storage probe failure")
+
+
+def test_patcher_device_files_resolves_bare_names_per_device():
+    axera = Device(device_type="d4sh", petkit_id=7)
+    set_patch_storage_dir(axera, "/opt")
+    ing = Device(device_type="d4sh", petkit_id=8)
+    set_patch_storage_dir(ing, "/system")
+    info = {"files": ["cloud_patched", "ca_patched.crt"]}
+    assert patcher_device_files(info, ing) == [
+        "/system/cloud_patched", "/system/ca_patched.crt"]
+    assert patcher_device_files(info, axera) == [
+        "/opt/cloud_patched", "/opt/ca_patched.crt"]
+
+
+def test_patcher_device_files_keeps_absolute_paths():
+    d = Device(device_type="d4sh", petkit_id=7)
+    set_patch_storage_dir(d, "/opt")
+    info = {"files": ["/etc/fixed.conf", "/var/lib/fixed.state"]}
+    assert patcher_device_files(info, d) == [
+        "/etc/fixed.conf", "/var/lib/fixed.state"]
+
+
+def test_ssh_install_commands_use_system_on_ingenic_layout():
+    d = Device(device_type="d4sh", petkit_id=7)
+    set_patch_storage_dir(d, "/system")
+    cmd = "\n".join(build_install_commands("http://host/patcher", "dropbear-mipsel", d))
+    assert "/system/dropbear" in cmd
+    assert "/system/authorized_keys" in cmd
+    assert "/system/dbkey_ecdsa" in cmd
+    assert "/opt/dropbear" not in cmd
+
+
+def test_ssh_install_commands_use_opt_on_axera():
+    d = Device(device_type="d4sh", petkit_id=7)
+    set_patch_storage_dir(d, "/opt")
+    cmd = "\n".join(build_install_commands("http://host/patcher", "dropbear-armv7", d))
+    assert "/opt/dropbear" in cmd
+    assert "/opt/authorized_keys" in cmd
+    assert "/opt/dbkey_ecdsa" in cmd
+    assert "/opt/test_case_root" in cmd
+    assert "/system/dropbear" not in cmd
+
+
 # --- build_wrapper_upload_cmd ---
 
 def test_upload_cmd_writes_wrapper():
@@ -240,9 +352,27 @@ def test_upload_cmd_escapes_single_quotes():
     assert "printf '" in cmd
 
 
+def test_axera_upload_cmd_writes_opt_wrapper():
+    d = Device(device_type="d4sh", petkit_id=7)
+    set_patch_storage_dir(d, "/opt")
+    cmd = build_wrapper_upload_cmd({"cloud"}, d)
+    assert OPT_APP_INIT_WRAPPER in cmd
+    assert "mount --bind /opt/cloud_patched /app/bin/cloud" in cmd
+    assert "/system/app_init.sh" not in cmd
+
+
 # --- build_wrapper_remove_cmd ---
 
 def test_remove_cmd():
     cmd = build_wrapper_remove_cmd()
     assert "rm -f" in cmd
     assert APP_INIT_WRAPPER in cmd
+
+
+def test_axera_remove_cmd_removes_opt_wrapper():
+    d = Device(device_type="d4sh", petkit_id=7)
+    set_patch_storage_dir(d, "/opt")
+    cmd = build_wrapper_remove_cmd(d)
+    assert "rm -f" in cmd
+    assert OPT_APP_INIT_WRAPPER in cmd
+    assert APP_INIT_WRAPPER not in cmd


### PR DESCRIPTION
## Summary

Fix patcher persistence on Axera ARM devices by choosing the device’s real writable app storage at runtime instead of assuming the Ingenic `/system` layout.

This matters because some device type strings, especially D4SH, can represent either MIPS/Ingenic or ARM/Axera hardware. The patcher now detects the persistent storage location from the device itself:

- `/system/user.conf` present -> use `/system`
- `/opt/user.conf` present -> use `/opt`
- neither present -> fail loudly instead of guessing

## Changes

- Add device-aware patch storage helpers for `/system` vs `/opt`.
- Resolve patcher file paths from bare names like `cloud_patched`, `ctrl_patched`, and `dropbear`.
- Write the boot wrapper to `/system/app_init.sh` or `/opt/app_init.sh` based on detected storage.
- Apply the same path handling to MQTT, cloud, CA cert, camera wrapper, and SSH/dropbear.
- Keep CPU architecture detection based on ELF headers, not device type strings.
- Persist the detected storage path in device config after probing.
- Update patcher descriptions/docs from W7H-specific wording to Ingenic/Axera platform wording.
- Add tests for `/system` and `/opt` path resolution and storage detection.

## Testing

- `pytest addon/tests/test_patchers.py -k "not stage_and_get" addon/tests/test_patcher_space.py`
- `pytest addon/tests/test_panel.py -k "all_patchers_are_offered"`
- Import smoke checks for patcher modules
