### PR TITLE
Fix multiple small bugs on device panels

### DIFF
--- a/addon/petkit_local/devices/base.py
+++ b/addon/petkit_local/devices/base.py
@@ -645,10 +645,39 @@ class Device:
         if self.is_feeder and self.is_camera:
             return {"result": {
                 "detectMultiRange": mc("detectMultiRange", [[0, 1440]]),
-                "cameraMultiNew": mc("cameraMultiNew", [[0, 1440]]),
+                # Format B on D4SH, not A — a bare [[start,end]] fails every
+                # item's `cJSON_GetObjectItem(item, "rpt")` lookup and leaves
+                # the schedule table empty, silently disabling continuous
+                # recording (see the schema doc's own war story about this).
+                "cameraMultiNew": mc("cameraMultiNew", [
+                    {"enable": 1, "rpt": "1,2,3,4,5,6,7", "time": [[0, 1440]]}
+                ]),
                 "toneMultiRange": mc("toneMultiRange", [[1320, 360]]),
                 "lightMultiRange": mc("lightMultiRange", [[0, 1440]]),
             }}
+        if self.is_water_fountain:
+            # Confirmed by decompiling `net_dev_multi_config_get`
+            # (`0x000251ac`); a live cloud capture only exercised the first 4
+            # (below the "----"), the other 4 are unverified defaults matching
+            # the paired mode switches' own off-by-default state. No HA entity
+            # reads or writes any of these yet — deliberately not exposed
+            # until real schedule values are captured.
+            result = {
+                "lightMultiRange": mc("lightMultiRange", [[0, 1440]]),
+                "toneMultiRange": mc("toneMultiRange", [[1320, 360]]),
+                "distrubMultiRange": mc("distrubMultiRange", [[40, 520]]),
+                "cameraMultiRange": mc("cameraMultiRange", [
+                    {"enable": 1, "rpt": "1,2,3,4,5,6,7", "time": [[0, 1440]]}
+                ]),
+                # ----
+                "wlDisturbMultiRange": mc("wlDisturbMultiRange", [[-1, -1]]),
+                "awDisturbMultiRange": mc("awDisturbMultiRange", [[-1, -1]]),
+                "wifiLightAssistMultiRange": mc("wifiLightAssistMultiRange", []),
+                "lightAssistMultiRange": mc("lightAssistMultiRange", [
+                    {"rpt": "1,2,3,4,5,6,7", "time": []}
+                ]),
+            }
+            return {"result": result}
         return {"result": {}}
 
     def to_video_device_info(self) -> dict[str, Any]:

--- a/addon/petkit_local/devices/categories.py
+++ b/addon/petkit_local/devices/categories.py
@@ -176,6 +176,15 @@ CATEGORY_SPECS: dict[str, CategorySpec] = {
             "ble_response/post",
         ),
         camera_state_topics=("move_detect", "pet_detect"),
+        # T6 has no deodorant/spray cartridge system at all, unlike T5 — no
+        # N50, no N60, nothing for either to report or control.
+        model_excludes=(
+            ("t6", frozenset({
+                "n50_durability", "n60_spray_days", "waste_bin_present",
+                "deodorization_running", "auto_spray", "fixed_time_spray",
+                "deep_spray", "deodorize", "reset_n50",
+            })),
+        ),
     ),
     "feeder": CategorySpec(
         device_types=frozenset(DEVICE_TYPES_FEEDER),

--- a/addon/petkit_local/ha/commands.py
+++ b/addon/petkit_local/ha/commands.py
@@ -56,6 +56,11 @@ CAPABILITY_VALUE_PREFIX = "capabilities."
 # feeder never had and cannot be talked out of.
 LOCAL_VALUE_PREFIX = "local."
 
+# `surplusControl` value -> the `surplusStandard` level it pairs with, from a
+# live D4SH capture of the app's own writes (2026-08-08). `0` (off) has no
+# entry: the app left `surplusStandard` untouched when switching off.
+SURPLUS_CONTROL_TO_STANDARD = {30: 1, 60: 2, 80: 3}
+
 #: Starting values for the `local.` controls, so their entities render a number
 #: instead of "unknown" before anyone touches them. Both are 1 because that is
 #: what PetKit's app sends for its own default manual feed on a Dual-Hopper,
@@ -421,6 +426,26 @@ def handle_ha_command(device: Device, entity: EntityDef, payload: str) -> Comman
                 "takes effect on the next dev_oss_sts_info_new_v2 poll)",
                 cap, value, device.petkit_id)
         return None
+
+    # `surplus_level` writes a PAIR, not a single field: `surplusControl`
+    # carries on/off and level together (0/30/60/80), `surplusStandard`
+    # mirrors the level (1/2/3) and is captured live to be left untouched when
+    # switching off — see ha/entities/selects.py::FEEDER_SELECTS.
+    if comp == "select" and entity.key == "surplus_level":
+        value = _select_value(entity, payload)
+        if value is None:
+            log.warning("Could not coerce payload %r for entity '%s'", payload, entity.key)
+            return None
+        settings = device.config.setdefault("settings", {})
+        settings["surplusControl"] = value
+        params = {"surplusControl": value}
+        level = SURPLUS_CONTROL_TO_STANDARD.get(value)
+        if level is not None:
+            settings["surplusStandard"] = level
+            params["surplusStandard"] = level
+        log.info("Setting surplusControl=%s (surplusStandard=%s) for device %d",
+                 value, level, device.petkit_id)
+        return (PROPERTY_SET_SUFFIX, make_mqtt_property_set(params))
 
     if comp == "button":
         # A consumable reset is recorded HERE, not inferred from the device's

--- a/addon/petkit_local/ha/entities/selects.py
+++ b/addon/petkit_local/ha/entities/selects.py
@@ -29,13 +29,17 @@ FEEDER_SELECTS = [
     # because `to_device_info` serves seeded settings back to the device and a
     # made-up value would change the owner's setting.
     #
-    # KNOWN INCOMPLETE: the reference integration writes the PAIR
-    # {"surplusControl": 1, "surplusStandard": <level>} and this sends only the
-    # first half, so the level probably does not take effect. Fixing it needs a
-    # feeder capture showing what the device expects.
+    # The encoding is NOT the paired {0/1} + {1-3} model the reference
+    # integration assumes. Captured live from a D4SH tracking the app's own
+    # writes (2026-08-08): Off=`{surplusControl:0}`, Less=`{30,1}`,
+    # Moderate=`{60,2}`, Full=`{80,3}` — `surplusControl` alone carries both
+    # on/off and level, `surplusStandard` mirrors the level and is left
+    # untouched (not re-zeroed) when switching off. See the paired write in
+    # `ha/commands.py::handle_ha_command`.
     EntityDef(component="select", key="surplus_level", name="Surplus Level",
               value_path="settings.surplusControl", icon="mdi:bowl-mix",
-              options=["disabled", "less", "moderate", "full"]),
+              options=["disabled", "less", "moderate", "full"],
+              option_values=[0, 30, 60, 80]),
 ]
 
 FOUNTAIN_SELECTS = [

--- a/addon/petkit_local/ha/entities/switches.py
+++ b/addon/petkit_local/ha/entities/switches.py
@@ -149,7 +149,7 @@ FOUNTAIN_SWITCHES = [
 # already ship is handled by `pet_det_Enable`.
 #
 # Deliberately NOT here: `flushIntensity`, `flushCycle`, `flushTime`,
-# `waterChangeCycle`, `waterChangeTime`, `addWaterMode` and `targetTemp`. All
+# `waterChangeCycle`, `waterChangeTime`, `addWaterMode` and `heaterTemp`. All
 # are real handlers, but a number or select needs a RANGE and the map gives
 # none, and `Device.to_device_info` serves settings back to the device — so an
 # invented bound is not a display detail, it is a value we would push.

--- a/addon/petkit_local/web/static/app.js
+++ b/addon/petkit_local/web/static/app.js
@@ -668,7 +668,12 @@ function renderPanelBody(d) {
   // the other direction.
   const byCategory = (a, b) => (a.entity_category ? 1 : 0) - (b.entity_category ? 1 : 0);
 
-  const sensors = ents.filter(e => section(e) === 'state').sort(byCategory);
+  // Hall switches are internal mechanism diagnostics, not something anyone
+  // checks day to day — 20+ of them on a camera litter would otherwise
+  // dominate the State card. Still reachable under "Show every entity".
+  const sensors = ents
+    .filter(e => section(e) === 'state' && !e.key.startsWith('hall_'))
+    .sort(byCategory);
   const controls = ents.filter(e => section(e) === 'controls' && !relocated(e)).sort(byCategory);
   const schedules = ents.filter(e => section(e) === 'schedules');
   const media = ents.filter(e => section(e) === 'camera');
@@ -1127,15 +1132,20 @@ function controlRow(id, e, kind) {
         data-input="entity-number" data-id="${esc(id)}" data-key="${esc(e.key)}" data-device-value="${esc(e.value ?? '')}">
       <button class="mini" data-action="set-entity-number" data-id="${esc(id)}" data-key="${esc(e.key)}"${k}>Set</button></span></label>`;
   }
-  // select — device value maps to an option via option_values (else by index/label)
-  let sel = -1;
-  if (e.option_values && e.option_values.length)
-    sel = e.option_values.findIndex(v => String(v) === String(e.value));
+  // select — device value maps to an option via option_values, or by bare
+  // index when an entity declares none (ha/discovery.py::_select_value_template
+  // does the same fallback server-side: `option_values or range(len(options))`).
+  // This used to compare the raw device value against the option LABEL STRING
+  // in the no-option_values case, which never matches an int like `1` against
+  // "continuous" — flow_mode was the only select relying on that fallback, and
+  // every selection silently reverted to the first option on repaint.
+  const values =
+    e.option_values && e.option_values.length
+      ? e.option_values
+      : (e.options || []).map((_, idx) => idx);
+  const sel = values.findIndex(v => String(v) === String(e.value));
   const opts = (e.options || [])
-    .map(
-      (o, idx) =>
-        `<option ${idx === sel || (sel < 0 && String(e.value) === String(o)) ? 'selected' : ''}>${esc(o)}</option>`,
-    )
+    .map((o, idx) => `<option ${idx === sel ? 'selected' : ''}>${esc(o)}</option>`)
     .join('');
   return `<label class="ctrl"><span>${nm}</span>
     <span class="cn"><select data-change="set-entity-select" data-id="${esc(id)}" data-key="${esc(e.key)}"${k}>${opts}</select></span></label>`;

--- a/addon/tests/test_commands.py
+++ b/addon/tests/test_commands.py
@@ -21,6 +21,12 @@ def _litter():
     return d, _settable_index(d)
 
 
+def _feeder():
+    d = Device(device_type="d4sh", petkit_id=1, serial_number="SN")
+    d.config.setdefault("settings", d.default_settings())
+    return d, _settable_index(d)
+
+
 def test_switch_updates_settings_and_returns_mqtt():
     d, idx = _litter()
     res = handle_ha_command(d, idx["auto_work"], "OFF")
@@ -101,6 +107,24 @@ def test_select_explicit_values():
     d, idx = _litter()
     _, payload = handle_ha_command(d, idx["cleaning_interval"], "1h")
     assert payload["params"] == {"autoIntervalMin": 60}
+
+
+def test_surplus_level_writes_the_pair():
+    """`surplusControl` alone carries on/off + level (0/30/60/80); the level
+    is mirrored into `surplusStandard` too, per a live D4SH capture."""
+    d, idx = _feeder()
+    _, payload = handle_ha_command(d, idx["surplus_level"], "moderate")
+    assert payload["params"] == {"surplusControl": 60, "surplusStandard": 2}
+    assert d.config["settings"]["surplusControl"] == 60
+    assert d.config["settings"]["surplusStandard"] == 2
+
+
+def test_surplus_level_disabled_leaves_standard_untouched():
+    d, idx = _feeder()
+    d.config["settings"]["surplusStandard"] = 3
+    _, payload = handle_ha_command(d, idx["surplus_level"], "disabled")
+    assert payload["params"] == {"surplusControl": 0}
+    assert d.config["settings"]["surplusStandard"] == 3
 
 
 def test_button_returns_mqtt_service_envelope():

--- a/addon/tests/test_entities.py
+++ b/addon/tests/test_entities.py
@@ -46,7 +46,12 @@ EXPECTED_ENTITY_COUNTS = {
     # 42 -> 50 on the D4H, which reports one hopper; the D4SH keeps its second
     # hopper sensor and adds the two per-hopper feed buttons and their portion
     # numbers, for 54.
-    "t3": 45, "t4": 45, "t5": 73, "t6": 73, "t7": 73,
+    # T6 dropped 9 on 2026-08-08: it has no deodorant/spray cartridge system
+    # at all, unlike T5/T7 — no N50, no N60, nothing for either to report or
+    # control (n50_durability, n60_spray_days, waste_bin_present,
+    # deodorization_running, auto_spray, fixed_time_spray, deep_spray,
+    # deodorize, reset_n50).
+    "t3": 45, "t4": 45, "t5": 73, "t6": 64, "t7": 73,
     "feeder": 25, "feedermini": 25, "d3": 25, "d4": 25, "d4s": 25,
     "d4h": 50, "d4sh": 54,
     "w4": 24, "w5": 24, "ctw2": 24, "ctw3": 24, "w7h": 67,

--- a/addon/tests/test_http.py
+++ b/addon/tests/test_http.py
@@ -531,6 +531,46 @@ async def test_multi_config_json_strings():
         await client.close()
 
 
+async def test_d4sh_camera_multi_new_is_format_b():
+    """`cameraMultiNew` is Format B (per-weekday `{rpt, time}` objects) on
+    D4SH, never Format A — sending flat `[start,end]` pairs makes every item
+    fail the firmware's `rpt` lookup and silently empties the schedule table,
+    disabling continuous recording."""
+    reg = DeviceRegistry()
+    client = await _client(reg)
+    try:
+        await client.post("/6/d4sh/dev_signup", headers=HDR)
+        r = await client.post("/6/d4sh/dev_multi_config", headers=HDR)
+        res = (await r.json())["result"]
+        cam_new = json.loads(res["cameraMultiNew"])["cameraMultiNew"]
+        assert "rpt" in cam_new[0]
+        assert "time" in cam_new[0]
+    finally:
+        await client.close()
+
+
+async def test_w7h_multi_config_covers_all_eight_fields():
+    """W7H's `to_multi_config` was previously unhandled (`{"result": {}}`).
+    All 8 fields the firmware decompile confirms it reads should now be
+    present, Format A as flat pairs and Format B as `{rpt, time}` objects."""
+    reg = DeviceRegistry()
+    client = await _client(reg)
+    try:
+        await client.post("/6/w7h/dev_signup", headers=HDR)
+        r = await client.post("/6/w7h/dev_multi_config", headers=HDR)
+        res = (await r.json())["result"]
+        for key in ("lightMultiRange", "toneMultiRange", "distrubMultiRange",
+                    "wlDisturbMultiRange", "awDisturbMultiRange",
+                    "wifiLightAssistMultiRange"):
+            assert isinstance(res[key], str)
+        cam = json.loads(res["cameraMultiRange"])["cameraMultiRange"]
+        assert cam[0]["rpt"] == "1,2,3,4,5,6,7"
+        light_assist = json.loads(res["lightAssistMultiRange"])["lightAssistMultiRange"]
+        assert "rpt" in light_assist[0]
+    finally:
+        await client.close()
+
+
 async def test_ota_check_is_an_empty_object():
     reg = DeviceRegistry()
     client = await _client(reg)


### PR DESCRIPTION
Fix W7H schedule config, surplusControl encoding, D4SH camera schedule format, and panel select rendering

Several bugs found while auditing settings-endpoint coverage against firmware RE data and live device captures:

- D4SH's cameraMultiNew was sent as Format A (flat range pairs) instead of the Format B ({rpt, time} objects) the firmware actually reads, silently emptying the schedule table and disabling continuous recording.
- surplusControl was wired as a raw 0-3 select with no surplusStandard pairing; a live capture of the app's own writes gave the real encoding (0=off, 30/60/80=less/moderate/full, paired with surplusStandard 1/2/3).
- W7H's to_multi_config had no water-fountain branch at all (wlDisturbMultiRange, awDisturbMultiRange, wifiLightAssistMultiRange, lightAssistMultiRange), despite the firmware decompile confirming it reads all of them. Not exposed as HA entities yet — no real schedule values captured to seed correct defaults.
- T6 has no deodorant/spray cartridge hardware at all, unlike T5/T7, but shared entity lists shipped it N50/N60 sensors, spray switches and buttons anyway. Excluded via model_excludes.
- The panel's select rendering compared the raw device value against the option label string when an entity declared no option_values, instead of matching by index the way ha/discovery.py's server-side template does. flow_mode (W7H fountain mode) was the only select relying on that fallback, so it always reverted to the first option on repaint even though the correct MQTT command had already been sent.
- Hall switches (~20 internal mechanism diagnostics on camera litters) are now hidden from the panel's State card by default, still reachable under "Show every entity". They're not very human readable anyway.