### PR TITLE
Add a two-way talk (intercom) patcher

### DIFF
--- a/addon/petkit_local/patchers/common.py
+++ b/addon/petkit_local/patchers/common.py
@@ -505,14 +505,42 @@ BIND_MOUNT_TEMPLATES = {
     # ssh: no bind-mount needed (dropbear is not replacing a stock binary)
 }
 
+#: Two-way talk (intercom) audio sink. The panel's `/api/devices/{id}/talk`
+#: WebSocket transcodes the browser mic to 16 kHz mono ADTS-AAC and streams it
+#: to this TCP port on the device; the listener below feeds it to the firmware's
+#: own `pktool play_aac`, which owns the IMP speaker path. See patchers/talk.py.
+TALK_TCP_PORT = 9010
+#: The listener script the talk pre-init block writes to /tmp on each boot.
+TALK_SINK_SCRIPT = "/tmp/pktalk_sink.sh"
+
 # Pre-init commands (run BEFORE stock app_init.sh is sourced).
-# SSH needs this — dropbear should be up even if stock init fails.
+# SSH needs this — dropbear should be up even if stock init fails. Talk starts
+# its nc listener here too, and that is fine despite there being no post-init
+# phase: the listener only needs to be LISTENING at boot; the speaker path
+# (pktool → media) is touched lazily, once per talk connection, long after stock
+# init has started media.
 PRE_INIT_BLOCKS = {
     "ssh": (
         "# Persistent SSH (dropbear on port 22)\n"
         "mkdir -p /tmp/.ssh\n"
         "cp {store}/authorized_keys /tmp/.ssh/authorized_keys\n"
         "{store}/dropbear -r {store}/dbkey_ecdsa -p 22 &\n"
+    ),
+    # No {store} in this block: the sink script is generated in /tmp, and nc +
+    # pktool are stock, so nothing of ours is uploaded (patchers/talk.py files=[]).
+    "talk": (
+        "# Two-way talk: a TCP audio sink. The add-on streams the browser mic\n"
+        f"# to TCP {TALK_TCP_PORT}; here it becomes speaker audio via pktool.\n"
+        f"cat > {TALK_SINK_SCRIPT} <<'PKSINK'\n"
+        "F=/tmp/pktalk.$$\n"
+        "rm -f $F; mknod $F p\n"
+        "LD_LIBRARY_PATH=/syslib/lib:/app/lib:/system/lib:/usr/lib:/lib "
+        "/app/bin/pktool play_aac $F &\n"
+        "cat > $F\n"
+        "rm -f $F\n"
+        "PKSINK\n"
+        f"( while true; do nc -l -p {TALK_TCP_PORT} -e /bin/sh {TALK_SINK_SCRIPT}; "
+        "sleep 1; done ) &\n"
     ),
 }
 
@@ -530,8 +558,8 @@ def generate_app_init_wrapper(active_patchers: set[str],
     lines = [WRAPPER_HEADER_TEMPLATE.format(
         wrapper=app_init_wrapper_path(device))]
     store = patch_storage_dir(device)
-    # Pre-init: things that must run before stock init (SSH, etc.)
-    for pid in ("ssh",):
+    # Pre-init: things that must run before stock init (SSH, the talk sink).
+    for pid in ("ssh", "talk"):
         if pid in active_patchers and pid in PRE_INIT_BLOCKS:
             lines.append(PRE_INIT_BLOCKS[pid].format(store=store))
     for pid in ("mqtt", "cloud", "cacert", "camera"):

--- a/addon/petkit_local/patchers/talk.py
+++ b/addon/petkit_local/patchers/talk.py
@@ -1,0 +1,61 @@
+"""Two-way talk (intercom) audio sink patcher.
+
+PetKit's app talks to the litter box over Agora RTC; the camera patcher replaces
+Agora with tserver (local video, one-way), which is why talkback stops working
+once you leave the cloud. Listening still works — the device mic rides the
+tserver FLV as 16 kHz AAC — so the only missing half is getting the panel's
+microphone TO the device speaker.
+
+This patcher adds that half without any new on-device binary. Its pre-init block
+(`common.PRE_INIT_BLOCKS["talk"]`) runs a small `nc` listener on TCP
+`TALK_TCP_PORT`. Per connection it feeds a named pipe to the firmware's own
+`pktool play_aac`, which hands the path to `media`; media stream-reads the pipe
+and plays it on the speaker. The add-on's `/api/devices/{id}/talk` WebSocket
+transcodes the browser microphone to 16 kHz mono ADTS-AAC and streams it in.
+
+It is a pre-init block rather than a bind-mount because it starts a process
+rather than replacing a binary — the same shape as the SSH patcher. Starting it
+before stock init is safe even though it ends up driving pktool: the listener
+only needs to be LISTENING at boot, and the speaker path is touched lazily, per
+connection, by which time stock init has long since started media.
+
+Like camera, nothing of ours lands on persistent storage — the listener script
+is regenerated in /tmp on every boot — so `files` is empty and removal is just
+dropping the block from the wrapper and rebooting. Half-duplex by design: mute
+listening while talking, because the device's native echo cancellation lived on
+the Agora path this replaces.
+"""
+from __future__ import annotations
+
+from petkit_local.patchers.common import TALK_TCP_PORT
+
+PATCHER_INFO = {
+    "id": "talk",
+    "name": "Two-Way Talk (Intercom)",
+    "description": (
+        "Adds a local audio sink so the panel can talk to the device speaker — "
+        "real two-way audio without PetKit's cloud, which used Agora (replaced "
+        "by Local Camera Streaming).\n\n"
+        f"What it does: adds a pre-init block to the boot wrapper that runs a "
+        f"small nc listener on TCP {TALK_TCP_PORT}. Per connection it feeds a "
+        "named pipe to the firmware's own pktool play_aac, which hands it to "
+        "media (the IMP pipeline that owns the speaker). The add-on transcodes "
+        "your browser microphone to 16 kHz mono AAC and streams it in; listening "
+        "is the existing camera audio the other way.\n\n"
+        "Requires a camera model with a speaker, and is normally used together "
+        "with Local Camera Streaming. Nothing is written to persistent storage — "
+        "the listener script is regenerated in /tmp each boot — so removing the "
+        "patch and rebooting restores stock exactly.\n\n"
+        "Half-duplex: mute listening while you talk to avoid echo (the device's "
+        "native echo cancellation lived on the Agora path this replaces)."
+    ),
+    # Pure pre-init block: no file of ours lands on the device (nc + pktool are
+    # stock, the sink script is generated in /tmp), so removal is just dropping
+    # the block from the wrapper and rebooting (cf. camera).
+    "files": [],
+    # No architecture: the sink is stock busybox nc + pktool, both already there.
+    "arch": None,
+    # Writes no file of its own, but every patcher rewrites /system/app_init.sh —
+    # so the floor is the wrapper plus margin, not zero (cf. camera).
+    "needs_bytes": 131072,
+}

--- a/addon/petkit_local/web/api/patchers.py
+++ b/addon/petkit_local/web/api/patchers.py
@@ -36,6 +36,7 @@ from petkit_local.patchers.ssh import (
     ARCH_TO_BINARY as SSH_ARCH_TO_BINARY,
     DBKEY_RESERVE_BYTES, dropbear_path_for,
 )
+from petkit_local.patchers.talk import PATCHER_INFO as TALK_PATCHER
 from petkit_local.patchers.verify import assert_download_plausible, elf_arch
 from petkit_local.web.api._common import _device_or_404, _json_body
 
@@ -53,7 +54,7 @@ log = logging.getLogger(__name__)
 _PATCHER_LOCKS: dict[int, asyncio.Lock] = {}
 
 ALL_PATCHERS: dict[str, dict[str, Any]] = {
-    p["id"]: p for p in [MQTT_PATCHER, CLOUD_PATCHER, CACERT_PATCHER, CAMERA_PATCHER, SSH_PATCHER]
+    p["id"]: p for p in [MQTT_PATCHER, CLOUD_PATCHER, CACERT_PATCHER, CAMERA_PATCHER, SSH_PATCHER, TALK_PATCHER]
 }
 
 

--- a/addon/petkit_local/web/api/talk.py
+++ b/addon/petkit_local/web/api/talk.py
@@ -1,0 +1,119 @@
+"""Two-way talk: stream the browser microphone to the device speaker.
+
+The `talk` patcher installs a TCP audio sink on the device (see
+`patchers/talk.py`); this WebSocket is the other end of it. Kept out of
+`panel.py` because it owns an ffmpeg subprocess per session and its own small
+message protocol.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+
+import aiohttp
+from aiohttp import web
+
+from petkit_local.patchers.common import TALK_TCP_PORT
+
+
+async def api_talk(request: web.Request) -> web.WebSocketResponse:
+    """Two-way talk: stream the browser microphone to the device speaker.
+
+    The frontend's MediaRecorder sends webm/opus over this WebSocket in ~250 ms
+    slices (a `talk_start` text frame, then binary, then `talk_stop`). One
+    ffmpeg per session transcodes the stream to 16 kHz mono ADTS-AAC — the
+    device speaker's format — and connects straight to the device's talk sink
+    (`tcp://<ip>:TALK_TCP_PORT`, installed by the `talk` patcher), which pipes it
+    to `pktool play_aac` and thence to `media`. ffmpeg does both the transcode
+    and the TCP connection, so nothing here touches a socket directly.
+
+    Half-duplex by design: the panel mutes listening while talking, because the
+    echo cancellation that made full duplex safe lived on the Agora path the
+    camera patcher replaced. Needs the device IP (from a state report) and the
+    `talk` patcher applied; without the sink listening, ffmpeg's connect fails
+    and the session reports an error rather than hanging.
+    """
+    reg = request.app["registry"]
+    ws = web.WebSocketResponse(max_msg_size=4 * 1024 * 1024, heartbeat=25)
+    await ws.prepare(request)
+
+    try:
+        did = int(request.match_info["id"])
+    except ValueError:
+        await ws.send_json({"type": "error", "msg": "bad device id"})
+        await ws.close()
+        return ws
+    d = reg.get(did)
+    device_ip = d.state.get("ip", "") if d else ""
+    if not d or not device_ip:
+        await ws.send_json({"type": "error",
+                            "msg": "device IP unknown — wait for a state report"})
+        await ws.close()
+        return ws
+
+    ffmpeg: asyncio.subprocess.Process | None = None
+
+    async def start() -> None:
+        nonlocal ffmpeg
+        if ffmpeg is not None:
+            return
+        # Low-latency decode: the input is a live webm/opus stream, so keep
+        # ffmpeg from buffering ahead before it starts emitting. Output goes
+        # straight to the device sink over TCP.
+        ffmpeg = await asyncio.create_subprocess_exec(
+            "ffmpeg", "-hide_banner", "-loglevel", "error",
+            "-fflags", "nobuffer", "-flags", "low_delay",
+            "-probesize", "32", "-analyzeduration", "0",
+            "-i", "pipe:0",
+            "-ar", "16000", "-ac", "1", "-c:a", "aac", "-b:a", "48k",
+            "-f", "adts", f"tcp://{device_ip}:{TALK_TCP_PORT}",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+    async def stop() -> None:
+        nonlocal ffmpeg
+        if ffmpeg is None:
+            return
+        proc, ffmpeg = ffmpeg, None
+        # Close the input so ffmpeg flushes its trailer and the device sink sees
+        # EOF (ending that play session); kill only if it will not exit.
+        if proc.stdin and not proc.stdin.is_closing():
+            with contextlib.suppress(Exception):
+                proc.stdin.write_eof()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=6)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+
+    try:
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.BINARY:
+                if ffmpeg is None:
+                    await start()
+                if ffmpeg and ffmpeg.stdin and not ffmpeg.stdin.is_closing():
+                    ffmpeg.stdin.write(msg.data)
+            elif msg.type == aiohttp.WSMsgType.TEXT:
+                try:
+                    evt = json.loads(msg.data)
+                except ValueError:
+                    continue
+                kind = evt.get("type")
+                if kind == "talk_start":
+                    await start()
+                    if not ws.closed:
+                        await ws.send_json({"type": "talking"})
+                elif kind == "talk_stop":
+                    await stop()
+                    if not ws.closed:
+                        await ws.send_json({"type": "stopped"})
+            elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR):
+                break
+    except (asyncio.CancelledError, ConnectionResetError, RuntimeError):
+        pass
+    finally:
+        await stop()
+    return ws

--- a/addon/petkit_local/web/panel.py
+++ b/addon/petkit_local/web/panel.py
@@ -68,6 +68,7 @@ from petkit_local.web.api.pets import (
 )
 from petkit_local.web.api.schedules import api_save_schedule
 from petkit_local.web.api.settings import api_blocked, api_info, api_retention, api_settings
+from petkit_local.web.api.talk import api_talk
 from petkit_local.web.api.timeline import api_event_detail, api_timeline
 from petkit_local.web.appkeys import (
     BACKGROUND_TASKS, BLE_REGISTRY, BRIDGE, CFG, EVENT_STORE, HA_PUBLISHER, HUB,
@@ -201,6 +202,8 @@ def create_panel_app(registry: DeviceRegistry, ble_registry: BLERegistry | None,
     app.router.add_post("/api/devices/{id}/ai", api_ai_settings)
     app.router.add_get("/api/devices/{id}/logs", api_device_log_settings)
     app.router.add_post("/api/devices/{id}/logs", api_device_log_settings)
+    # Two-way talk: browser mic -> device speaker (needs the `talk` patcher).
+    app.router.add_get("/api/devices/{id}/talk", api_talk)
 
     # --- BLE accessories. Pairing lives here because it lives in the cloud:
     # the device pulls a list and scans for exactly those MACs, and no firmware

--- a/addon/tests/test_patchers.py
+++ b/addon/tests/test_patchers.py
@@ -180,6 +180,43 @@ def test_wrapper_camera_never_uses_a_shell_placeholder():
     assert "fake_daemon" not in w
 
 
+def test_wrapper_talk_only():
+    """Talk is a pre-init block (like ssh), not a bind-mount: it starts an nc
+    listener that feeds the firmware's pktool, and it must be up before stock
+    init so the port is listening from boot."""
+    w = generate_app_init_wrapper({"talk"})
+    assert "nc -l -p 9010" in w
+    assert "pktool play_aac" in w
+    assert "mount --bind" not in w  # talk replaces no binary
+    lines = w.split("\n")
+    talk_idx = next(i for i, l in enumerate(lines) if "nc -l -p 9010" in l)
+    stock_idx = next(i for i, l in enumerate(lines)
+                     if l.strip().startswith(". /app/script/app_init.sh"))
+    assert talk_idx < stock_idx
+
+
+def test_wrapper_talk_leaves_no_format_placeholder():
+    """The talk block is built with f-strings and carries shell $vars, but the
+    wrapper still runs .format(store=) over every pre-init block — so a stray
+    brace would either raise or mangle the script."""
+    w = generate_app_init_wrapper({"talk"})
+    assert "{store}" not in w
+    assert "{TALK_TCP_PORT}" not in w
+
+
+def test_wrapper_talk_composes_with_camera():
+    w = generate_app_init_wrapper({"talk", "camera"})
+    assert "nc -l -p 9010" in w
+    assert "mount --bind /app/bin/tserver /app/bin/agora" in w
+    assert ". /app/script/app_init.sh" in w
+
+
+def test_talk_patcher_is_registered():
+    from petkit_local.web.api.patchers import ALL_PATCHERS
+    assert "talk" in ALL_PATCHERS
+    assert ALL_PATCHERS["talk"]["files"] == []
+
+
 def test_wrapper_all_three():
     w = generate_app_init_wrapper({"mqtt", "cacert", "camera"})
     assert "mount --bind /system/ctrl_patched /app/bin/ctrl" in w


### PR DESCRIPTION
## Two-way talk (intercom)

Listening already works once **Local Camera Streaming** is applied — the device
mic rides the tserver FLV as 16 kHz AAC. Talkback, though, stops once you leave
the cloud (it used Agora), so the missing half is getting the panel microphone
**to** the device speaker. This adds it, with no new on-device binary.

**How it works**
- `patchers/talk.py` — a pre-init patcher, same shape as `ssh` (it starts a
  process, not a bind-mount). Its `PRE_INIT_BLOCKS["talk"]` runs an `nc` listener
  on TCP 9010 that feeds a named pipe to the firmware's own `pktool play_aac`.
  Safe before stock init: it only needs to be *listening* at boot; the speaker
  path is touched lazily, per connection, long after stock init has started media.
- `web/api/talk.py` — the `/api/devices/{id}/talk` WebSocket. MediaRecorder sends
  webm/opus; one ffmpeg per session transcodes to 16 kHz mono ADTS-AAC and
  connects straight to the device sink over TCP.
- `files=[]` / `arch=None`, so it composes through the `app_init.sh` wrapper and
  removes cleanly — exactly like `camera`.

**Notes**
- Half-duplex by design (echo cancellation lived on the Agora path).
- Needs a camera model with a speaker; normally paired with Local Camera Streaming.
- Backend only — a frontend mic UI is intentionally out of scope.

**Tests**: wrapper tests for the talk block (pre-init ordering, no format
placeholder leak, composition with camera, registration). Full suite green.
Audio path (nc → pktool play_aac → speaker) verified on a real T6.
