### PR TITLE
Add T6 camera pan buttons (Left/Right/Home)

### DIFF
--- a/addon/petkit_local/ha/categories.py
+++ b/addon/petkit_local/ha/categories.py
@@ -26,7 +26,7 @@ from petkit_local.ha.discovery import EntityDef
 from petkit_local.ha.entities.buttons import (
     FEEDER_BUTTONS, FEEDER_DUAL_BUTTONS,
     FOUNTAIN_BUTTONS, FOUNTAIN_W7H_BUTTONS,
-    LITTER_BUTTONS, LITTER_CAMERA_BUTTONS, LITTER_T6_BUTTONS,
+    LITTER_BUTTONS, LITTER_CAMERA_BUTTONS, LITTER_T6_BUTTONS, LITTER_T6_PTZ_BUTTONS,
 )
 from petkit_local.ha.entities.camera import CAMERA_ENTITIES
 from petkit_local.ha.entities.events import (
@@ -185,7 +185,7 @@ CATEGORY_SPECS: dict[str, CategorySpec] = {
         ),
         camera_state_topics=("move_detect", "pet_detect"),
         model_entities=(
-            ("t6", LITTER_T6_BUTTONS),
+            ("t6", (*LITTER_T6_BUTTONS, *LITTER_T6_PTZ_BUTTONS)),
         ),
         # The Purobot Ultra has no N50 cartridge, so the button that claims to
         # reset one cannot be right on this model — and it is not merely inert.

--- a/addon/petkit_local/ha/command_router.py
+++ b/addon/petkit_local/ha/command_router.py
@@ -19,7 +19,8 @@ import logging
 from typing import TYPE_CHECKING, Any, AsyncIterable, Iterable
 
 from petkit_local.devices.ble import ble_command_for
-from petkit_local.ha.commands import Refused, handle_ha_command
+from petkit_local.ha.commands import RUN_CMD_SUFFIX, Refused, handle_ha_command
+from petkit_local.patchers.common import send_run_cmd
 from petkit_local.utils.coerce import to_int
 from petkit_local.utils.logtext import excerpt
 
@@ -249,6 +250,14 @@ class CommandRouter:
         # MQTT session, else queue for the next HTTP heartbeat poll.
         if result:
             service_suffix, mqtt_payload = result
+            # A `@run_cmd` is a shell line for the device's run_cmd path (the T6
+            # pan buttons), not a thing/service publish; send_run_cmd picks the
+            # transport itself, so it bypasses the publish/queue split below.
+            if service_suffix == RUN_CMD_SUFFIX:
+                await send_run_cmd(device, mqtt_payload["command"], self._command_sink)
+                self._registry.mark_dirty()
+                await self._publisher.publish_state(device)
+                return
             device_on_mqtt = self._command_sink is not None and device.mqtt_connected
             if device_on_mqtt:
                 try:

--- a/addon/petkit_local/ha/commands.py
+++ b/addon/petkit_local/ha/commands.py
@@ -40,6 +40,16 @@ Command = tuple[str, dict[str, Any]]
 
 PROPERTY_SET_SUFFIX = "property/set"
 
+# Sentinel suffix marking a command that is NOT a thing/service publish but a
+# shell line for the device's own `run_cmd` path (patchers/common.send_run_cmd,
+# delivered on user/get). The envelope is `{"command": "<shell>"}`, not an
+# Aliyun frame. Both command consumers — the panel (web/api/_common._deliver)
+# and the HA router (ha/command_router) — special-case it. This is how the T6
+# pan buttons reach `/system/motorctl`, the on-device motor tool, because the
+# camera's real-time PTZ runs over Agora RTM and has no HTTP/MQTT command to
+# reproduce (see the T6 pan button group in ha/entities/buttons.py).
+RUN_CMD_SUFFIX = "@run_cmd"
+
 # Media capability toggles (ha/entities/switches.py::CAPABILITY_SWITCHES) route
 # here instead of the generic settings.<field> path below: they don't push
 # anything to the device — the STS response (dev_oss_sts_info_new_v2) is the
@@ -173,6 +183,34 @@ def _device_power(on: bool) -> Command:
 SHARED_ACTIONS = {
     "power_off": lambda device: _device_power(False),
     "power_on": lambda device: _device_power(True),
+}
+
+# --- T6 camera pan (PTZ) --------------------------------------------------
+# The Purobot Ultra's camera sits on a single horizontal stepper. Its real-time
+# PTZ runs over Agora RTM (an end-to-end App<->device path), so there is no
+# cloud HTTP/MQTT command to reproduce — a proxy/capture never sees one. What
+# IS reachable is the device's own `/system/motorctl`, a small tool that drives
+# `/dev/motor` directly (the kernel clamps travel to 0..2500 and there is only
+# the one motor). Each button is one shell line, delivered like any other
+# run_cmd; the buttons are attached to the `t6` model only, in
+# ha/entities/buttons.py, because only that model has the motor.
+_MOTORCTL = "/system/motorctl"
+#: Steps per left/right nudge. Relative, so it composes from wherever the head
+#: is; the kernel clamps at each end. Left travels toward 0 (out into the room),
+#: right toward 2500 (home, lens over the drum).
+_PAN_STEP = 250
+#: The home coordinate: the rest position the firmware itself returns to.
+_PAN_HOME = 2500
+
+
+def _motorctl(args: str) -> Command:
+    return (RUN_CMD_SUFFIX, {"command": f"{_MOTORCTL} {args}"})
+
+
+PTZ_ACTIONS = {
+    "pan_left": lambda device: _motorctl(f"steps -{_PAN_STEP}"),
+    "pan_right": lambda device: _motorctl(f"steps {_PAN_STEP}"),
+    "pan_home": lambda device: _motorctl(f"coord {_PAN_HOME}"),
 }
 
 LITTER_ACTIONS = {
@@ -370,7 +408,8 @@ FOUNTAIN_ACTIONS = {
     "fountain_water_change": lambda device: _fountain_start(5),
 }
 
-ALL_ACTIONS = {**LITTER_ACTIONS, **FEEDER_ACTIONS, **FOUNTAIN_ACTIONS, **SHARED_ACTIONS}
+ALL_ACTIONS = {**LITTER_ACTIONS, **FEEDER_ACTIONS, **FOUNTAIN_ACTIONS, **SHARED_ACTIONS,
+               **PTZ_ACTIONS}
 
 
 def _coerce_switch(payload: str) -> int:

--- a/addon/petkit_local/ha/entities/buttons.py
+++ b/addon/petkit_local/ha/entities/buttons.py
@@ -59,6 +59,21 @@ LITTER_T6_BUTTONS = [
               icon="mdi:door-open"),
 ]
 
+# The T6's camera pans on a single horizontal stepper. These press-and-go
+# buttons drive `/system/motorctl` on the device (see
+# `ha/commands.py::PTZ_ACTIONS`); there is no absolute-position control, because
+# the head has no position report to bind one to — the motor's real-time PTZ
+# lives on Agora RTM, out of this add-on's sight. Only the `t6` model gets them
+# (it is the only one with the motor), via `categories.py` model_entities.
+LITTER_T6_PTZ_BUTTONS = [
+    EntityDef(component="button", key="pan_left", name="Camera Pan Left",
+              icon="mdi:arrow-left-bold-box"),
+    EntityDef(component="button", key="pan_right", name="Camera Pan Right",
+              icon="mdi:arrow-right-bold-box"),
+    EntityDef(component="button", key="pan_home", name="Camera Pan Home",
+              icon="mdi:image-filter-center-focus"),
+]
+
 FEEDER_BUTTONS = [
     EntityDef(component="button", key="feed", name="Feed", icon="mdi:food"),
     EntityDef(component="button", key="reset_desiccant", name="Reset Desiccant", icon="mdi:restart"),

--- a/addon/petkit_local/web/api/_common.py
+++ b/addon/petkit_local/web/api/_common.py
@@ -18,7 +18,9 @@ from typing import Any
 from aiohttp import web
 
 from petkit_local.devices.base import Device, split_bucket_authority
+from petkit_local.ha.commands import RUN_CMD_SUFFIX
 from petkit_local.http.proxy import resolve_upstream
+from petkit_local.patchers.common import send_run_cmd
 from petkit_local.utils.coerce import to_int
 
 log = logging.getLogger(__name__)
@@ -102,7 +104,18 @@ async def _deliver(hub, bridge, d, suffix: str, envelope: Any,
     from MQTT to the heartbeat queue is the part that must not diverge. A failed
     publish is not an error to the caller — the device picks the command up on
     its next poll either way — so `delivered` reports what actually happened.
+
+    A `@run_cmd` suffix is not a thing/service publish: it is a shell line for
+    the device's run_cmd path (the T6 pan buttons), delivered by `send_run_cmd`,
+    which picks MQTT-or-heartbeat itself and returns which it used.
     """
+    if suffix == RUN_CMD_SUFFIX:
+        command = envelope["command"]
+        used = await send_run_cmd(d, command, bridge)
+        hub.record_command(d.petkit_id, used, f"run_cmd {command[:80]}")
+        return web.json_response({"ok": True, "delivered": used, "suffix": suffix,
+                                  "envelope": envelope})
+
     if transport == "auto":
         mqtt_live = d.mqtt_connected and bridge is not None and getattr(bridge, "_client", None)
         transport = "mqtt" if mqtt_live else "heartbeat"

--- a/addon/tests/test_commands.py
+++ b/addon/tests/test_commands.py
@@ -461,3 +461,40 @@ def test_the_litter_type_seed_is_gone():
     idx = _settable_index(dev)
     _, payload = handle_ha_command(dev, idx["sand_type"], "mixed")
     assert payload["params"] == {"sandType": 3}
+
+
+# --- T6 camera pan (PTZ) ---------------------------------------------------
+
+def _t6():
+    d = Device(device_type="t6", petkit_id=6, serial_number="SN")
+    d.config.setdefault("settings", defaults.default_settings(d))
+    return d, _settable_index(d)
+
+
+def test_pan_buttons_are_run_cmd_not_thing_service():
+    """The pan buttons drive the on-device motor tool, so they resolve to a
+    `@run_cmd` shell line — never a thing/service publish (there is no cloud
+    PTZ command to send; the real-time path is Agora RTM)."""
+    from petkit_local.ha.commands import RUN_CMD_SUFFIX
+    d, idx = _t6()
+    for key, expect in (("pan_left", "steps -250"),
+                        ("pan_right", "steps 250"),
+                        ("pan_home", "coord 2500")):
+        suffix, envelope = handle_ha_command(d, idx[key], "")
+        assert suffix == RUN_CMD_SUFFIX, key
+        assert envelope == {"command": f"/system/motorctl {expect}"}, key
+
+
+def test_pan_buttons_exist_only_on_the_t6():
+    """Only the T6 has the motor, so no other litter box or feeder may offer
+    the pan buttons — they are attached by model, not by camera capability."""
+    pan = {"pan_left", "pan_right", "pan_home"}
+    for dt in ("t5", "t4", "t7", "d4h", "w7h"):
+        d = Device(device_type=dt, petkit_id=1, serial_number="SN")
+        keys = {e.key for e in get_entities_for_device(d)}
+        assert not (pan & keys), f"{dt} must not have pan buttons"
+    t6_keys = {e.key for e in get_entities_for_device(
+        Device(device_type="t6", petkit_id=1, serial_number="SN"))}
+    assert pan <= t6_keys
+    # And it stays a button, with no absolute-position number component.
+    assert "camera_pan" not in t6_keys

--- a/addon/tests/test_entities.py
+++ b/addon/tests/test_entities.py
@@ -52,13 +52,14 @@ EXPECTED_ENTITY_COUNTS = {
     # settings this add-on had been seeding and serving to the device with no
     # control for them (pet/wander/toilet detection, voice prompt, voice DND)
     # and three buttons (Light, Power Off, Power On) — 45 -> 46 and 73 -> 82.
-    # The T6 is 83: it drops `reset_n50`, which it has no cartridge for and
-    # whose code its own app uses for Pack, and adds Pack and Open Sealed Door.
+    # The T6 is 86: it drops `reset_n50`, which it has no cartridge for and
+    # whose code its own app uses for Pack, adds Pack and Open Sealed Door, and
+    # adds the three camera-pan buttons (Left/Right/Home) that drive its motor.
     #
     # 67 -> 84 on the W7H: nine camera and voice switches (it had a camera
     # entity and no way to switch the camera off), the two drain cycles and
     # their two times, volume, voice language, and the same two power buttons.
-    "t3": 46, "t4": 46, "t5": 82, "t6": 83, "t7": 82,
+    "t3": 46, "t4": 46, "t5": 82, "t6": 86, "t7": 82,
     "feeder": 25, "feedermini": 25, "d3": 25, "d4": 25, "d4s": 25,
     "d4h": 50, "d4sh": 54,
     "w4": 24, "w5": 24, "ctw2": 24, "ctw3": 24, "w7h": 84,

--- a/addon/tests/test_panel.py
+++ b/addon/tests/test_panel.py
@@ -27,9 +27,15 @@ class FakeBridge:
     def __init__(self, connected=False):
         self._client = object() if connected else None
         self.sent = []
+        self.run_cmds = []
 
     async def publish_to_device(self, device, suffix, payload):
         self.sent.append((device.petkit_id, suffix, payload))
+
+    async def publish_user_get(self, device, payload):
+        # The transport `send_run_cmd` uses for a @run_cmd (the T6 pan buttons).
+        self.run_cmds.append((device.petkit_id, payload))
+        return True
 
 
 def _panel(reg=None, ble=None, bridge=None, cfg=None):
@@ -381,6 +387,28 @@ async def test_command_sender_uses_bridge_when_connected():
         out = await r.json()
         assert out["delivered"] == "mqtt"
         assert bridge.sent and bridge.sent[0][1] == "start"
+    finally:
+        await c.close()
+
+
+async def test_pan_button_is_delivered_as_a_run_cmd_not_a_service_publish():
+    """A T6 pan press must go out on the device's run_cmd path (user/get),
+    never as a thing/service publish — there is no cloud PTZ command, the head
+    is driven by /system/motorctl on the box itself."""
+    reg = DeviceRegistry()
+    reg.get_or_create(petkit_id=1, device_type="t6", serial_number="SN")
+    reg.get(1).mqtt_connected = True
+    bridge = FakeBridge(connected=True)
+    app, reg, hub = _panel(reg=reg, bridge=bridge)
+    c = await _mk_client(app)
+    try:
+        r = await c.post("/api/devices/1/command", data=json.dumps({"action": "pan_left"}))
+        out = await r.json()
+        assert out["delivered"] == "mqtt"
+        assert bridge.sent == [], "a pan press must not thing/service publish"
+        assert bridge.run_cmds, "a pan press must go out as a run_cmd"
+        _, payload = bridge.run_cmds[0]
+        assert payload["user_cmd"]["run_cmd"] == "/system/motorctl steps -250"
     finally:
         await c.close()
 


### PR DESCRIPTION
The T6 (Purobot Ultra) camera sits on a single horizontal stepper. In the app,
panning it runs over **Agora RTM** — an end-to-end App↔device data channel — so
a proxy/capture never sees a cloud PTZ command, and there is none to reproduce
(no `net_*ptz` HTTP endpoint and no `thing.service` motor method exist in
`ctrl`; the motor is bound to `agora_ctrl_usrId`/`rtm_ptz_ctrl`). The only
non-Agora motor action is the `camera` privacy flip (a 180° turn via
`property.set`), which is already the Camera switch and gives just two positions.

What *is* reachable is the device's own `/dev/motor`. This adds three
press-and-go pan buttons that drive it through a tiny on-device tool, exactly
like Scoop or Pack — each button is one shell line, not a thing/service publish.

### The change (backend only)

- **`ha/commands.py`** — a `@run_cmd` sentinel suffix. An envelope under it is a
  shell line for the device's own run_cmd path (`patchers/common.send_run_cmd`,
  delivered on `user/get`), not an Aliyun frame. `PTZ_ACTIONS`
  (`pan_left`/`pan_right`/`pan_home`) return it, and **both** command consumers —
  the panel (`web/api/_common._deliver`) and the HA router
  (`ha/command_router`) — special-case it so it goes out as a run_cmd rather
  than a service publish.
- **`ha/entities/buttons.py` + `ha/categories.py`** — `LITTER_T6_PTZ_BUTTONS`,
  attached to the `t6` model only (the only litter box with the motor). No
  absolute-position `number`: the head has no position report to bind one to.

`pan_left` steps toward 0 (out into the room), `pan_right` toward 2500,
`pan_home` is the rest coordinate the firmware returns to. Golden T6 entity
count 83 → 86. Full suite green, ruff clean. New tests cover the sentinel
resolution and that the buttons exist only on the T6.

### The device side — please read before merging

The buttons are inert unless `/system/motorctl` exists on the device. That is
**not** firmware and is **not** in this diff — it is a ~2 KB static tool I built
and placed on the box. I have deliberately **not** committed a binary blob to
your tree. The full source is below so you can see exactly what a pan press
runs; it only ever does one clamped ioctl on `/dev/motor`, and the kernel itself
clamps travel to `[0, maxstep]`.

<details><summary><code>motorctl.c</code> (build: <code>zig cc -target mipsel-linux-musleabi -O2 -static motorctl.c -o motorctl-mipsel</code>, then copy to <code>/system/motorctl</code>, <code>chmod +x</code>)</summary>

```c
/* motorctl - minimal, safety-clamped controller for PetKit T6 camera pan.
 * /dev/motor (pk_motor, single motor = camera PAN only; verified motor_n==1).
 * ioctl cmd is used directly as the action index (0..7); arg is a pointer.
 * Kernel itself clamps COORD/STEPS target to [0, maxstep] and validates speed.
 */
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <fcntl.h>
#include <unistd.h>
#include <sys/ioctl.h>

#define M_STOP        0
#define M_STEPS       2   /* relative: arg=int delta,  kernel clamps result to [0,MAXSTEP] */
#define M_COORD       3   /* absolute: arg=int target, kernel clamps to [0,MAXSTEP]        */
#define M_GET_STATUS  4
#define M_SET_SPEED   5   /* arg = {u16 speed(200..800); u8 flag} (4 bytes)                */
#define M_RESET       6

#define MAXSTEP 2500
#define STEP_GUARD 400    /* extra userspace guard: never a single move > this many steps */

static int usage(const char *p){
    fprintf(stderr,"usage: %s status | coord <0..%d> | steps <-%d..%d> | speed <200..800> | stop\n",
            p, MAXSTEP, STEP_GUARD, STEP_GUARD);
    return 2;
}

int main(int argc, char **argv){
    if(argc<2) return usage(argv[0]);
    int fd=open("/dev/motor", O_RDWR);
    if(fd<0){ perror("open /dev/motor"); return 1; }
    int r=0;

    if(!strcmp(argv[1],"status")){
        unsigned char buf[64]; memset(buf,0,sizeof buf);
        r=ioctl(fd, M_GET_STATUS, buf);
        printf("GET_STATUS ret=%d\n", r);
        for(int i=0;i<6;i++){ unsigned int w; memcpy(&w, buf+i*4, 4); printf("  word[%d] (off %2d) = %u\n", i, i*4, w); }
    } else if(!strcmp(argv[1],"coord") && argc>=3){
        int v=atoi(argv[2]); if(v<0)v=0; if(v>MAXSTEP)v=MAXSTEP;
        r=ioctl(fd, M_COORD, &v); printf("COORD -> %d  ret=%d\n", v, r);
    } else if(!strcmp(argv[1],"steps") && argc>=3){
        int v=atoi(argv[2]); if(v>STEP_GUARD)v=STEP_GUARD; if(v<-STEP_GUARD)v=-STEP_GUARD;
        r=ioctl(fd, M_STEPS, &v); printf("STEPS %+d  ret=%d\n", v, r);
    } else if(!strcmp(argv[1],"speed") && argc>=3){
        int s=atoi(argv[2]); if(s<200)s=200; if(s>800)s=800;
        unsigned char sp[4]; sp[0]=s&0xff; sp[1]=(s>>8)&0xff; sp[2]=1; sp[3]=0;
        r=ioctl(fd, M_SET_SPEED, sp); printf("SET_SPEED %d  ret=%d\n", s, r);
    } else if(!strcmp(argv[1],"stop")){
        r=ioctl(fd, M_STOP, 0); printf("STOP ret=%d\n", r);
    } else return usage(argv[0]);

    close(fd);
    return r ? 1 : 0;
}
```

</details>

This bypasses `ctrl`'s own motor arbitration and its ADC end-stop detection, so
it is a deliberate local override — reasonable here because it is the only motor
and the kernel clamps the range, but worth your judgement. If you'd like the
install automated rather than manual, I'm happy to follow up with a `ptz`
patcher that ships `motorctl` and installs it to `/system` on boot, matching the
`ssh`/dropbear pattern already in `web/static/bin/`.

### Verified on hardware (T6)

A pan press from the panel travels panel → `send_run_cmd` → MQTT `user/get` →
device run_cmd → `/system/motorctl`, and the head moves to the exact expected
position: 1000 → `pan_left` → 750 → `pan_right` → 1000 → `pan_home` → 2500
(read back via `motorctl status`).
