### PR TITLE
Fix HA event entities: let HA parse the payload, and accept every type that fires

### DIFF
--- a/addon/petkit_local/events/codes.py
+++ b/addon/petkit_local/events/codes.py
@@ -805,6 +805,20 @@ MQTT_TRANSPORT_TOPICS = frozenset({"property", "property_post", "data_get",
                                    "ble_relay_over"})
 
 
+def mqtt_event_names(kind: str, families: frozenset[str]) -> list[str]:
+    """Every MQTT event name of `kind` that a device in `families` emits.
+
+    This is what an HA `event` entity's `event_types` list is derived from
+    (`ha/entities/events.py`): HA silently drops a fired event_type that the
+    discovery config did not declare, so the accepted list has to be THIS
+    table filtered the same way the firing side (`normalize.entity_for_event`)
+    resolves it — a hand-maintained copy is one more parallel collection to
+    drift. Order follows the table, which groups related cycles together.
+    """
+    return [name for name, code in MQTT_EVENT_TOPICS.items()
+            if code.kind == kind and code.families & families]
+
+
 # --- NS4: RecordType media classification ----------------------------------
 # Strings the cloud record API uses to classify recorded media. Distinct from
 # our moduleType -> category mapping in events/ingest.py: this namespace comes

--- a/addon/petkit_local/ha/discovery.py
+++ b/addon/petkit_local/ha/discovery.py
@@ -153,10 +153,11 @@ def build_discovery_payload(
         A dict always carrying `name`, `unique_id`, `object_id`, `device`
         (identifiers/name/manufacturer/model/serial_number) and `availability`
         (topic + online/offline payloads). Read-only components additionally
-        carry `state_topic` + `value_template`; settable ones carry
-        `command_topic` plus their component-specific keys (switch payloads,
-        number step and whichever of min/max the entity declares, select
-        options, text max, event event_types); the
+        carry `state_topic` + `value_template` — except `event`, whose payload
+        must reach HA's event platform as raw JSON (see the branch below);
+        settable ones carry `command_topic` plus their component-specific keys
+        (switch payloads, number step and whichever of min/max the entity
+        declares, select options, text max, event event_types); the
         the image component replaces `state_topic` with its own
         `topic`/`image_topic`. Optional `device_class`, `unit_of_measurement`,
         `icon` and `entity_category` appear only when set on the entity —
@@ -242,10 +243,17 @@ def build_discovery_payload(
 
     elif entity.component == "event":
         # Momentary HA event entity. Reads a dedicated non-retained topic where
-        # the bridge fires {"event_type": ...} when the device reports an event.
+        # `HAPublisher.publish_event` fires {"event_type": ..., <attributes>}
+        # when the device reports an event. NO value_template: HA's event
+        # platform renders the template first and then requires the RESULT to
+        # still be a JSON object carrying `event_type` (extra keys become the
+        # event's attributes). Extracting the string here made HA reject every
+        # single event — "No valid JSON event payload detected, value after
+        # processing payload 'clean_over'" — so the entities never left
+        # `unknown` and could not trigger an automation.
+        payload.pop("value_template", None)
         payload["state_topic"] = f"petkit-local/{device_id}/event/{entity.unique_id_suffix}"
         payload["event_types"] = entity.options
-        payload["value_template"] = "{{ value_json.event_type }}"
 
     elif entity.component == "image":
         # Raw (non-base64) image bytes retained on `image_topic` — no

--- a/addon/petkit_local/ha/entities/events.py
+++ b/addon/petkit_local/ha/entities/events.py
@@ -7,32 +7,35 @@ event_type onto one of the entities below and fires it non-retained, so an HA
 restart does not replay a visit that happened yesterday.
 
 `options` is the list of event_types HA will accept: an event_type fired but
-not listed here is rejected by HA, so the two must be kept in step. The device
-event_type strings themselves are not capture-confirmed — see
-`events/normalize.py`'s header for what is.
+not listed is silently dropped by HA. It is therefore DERIVED from
+`codes.MQTT_EVENT_TOPICS` — the same table the firing side dispatches on —
+filtered by the entity's kind and the device family the list serves. A
+hand-written copy is what used to be here, and it had drifted: a real T6's
+`light_over` fired into a `cleaning_event` whose declared list stopped at the
+cycles a T3 has. The device event_type strings themselves are not
+capture-confirmed — see `events/normalize.py`'s header for what is.
 
 `ha/categories.py` decides which of these lists a given device type gets.
 """
+from petkit_local.events import codes
 from petkit_local.ha.discovery import EntityDef
 
 LITTER_EVENTS = [
     EntityDef(component="event", key="toilet_event", name="Toilet Event",
               icon="mdi:cat",
-              options=["pet_in", "pet_out"]),
+              options=codes.mqtt_event_names(codes.KIND_TOILET, codes.LITTER)),
     EntityDef(component="event", key="cleaning_event", name="Cleaning Event",
               icon="mdi:broom",
-              options=["work_start", "work_continue", "work_suspend",
-                       "clean_over", "dump_over", "reset_over"]),
+              options=codes.mqtt_event_names(codes.KIND_CLEANING, codes.LITTER)),
     EntityDef(component="event", key="error_event", name="Error Event",
               icon="mdi:alert",
-              options=["error_start", "error_over"]),
+              options=codes.mqtt_event_names(codes.KIND_ERROR, codes.LITTER)),
 ]
 
 FEEDER_EVENTS = [
     EntityDef(component="event", key="feeding_event", name="Feeding Event",
               icon="mdi:food",
-              options=["feed_start", "feed_stop", "feed_over",
-                       "eat_start", "eat_over"]),
+              options=codes.mqtt_event_names(codes.KIND_FEEDING, codes.FEEDER)),
 ]
 
 #: The W7H's events. No other fountain publishes any: the Bluetooth EverSweets
@@ -40,18 +43,21 @@ FEEDER_EVENTS = [
 #:
 #: The keys are fixed by `events/normalize.py::KIND_TO_ENTITY`, which dispatches on
 #: the event's KIND — so this is `cleaning_event` even though what it fires is a
-#: water-treatment job. `options` is not: HA silently rejects an event_type not
-#: listed, and the litter list (`work_continue`, `dump_over`, ...) names cycles
-#: this device does not have. Before this existed a fountain's `work_start`
-#: published to a discovery topic the fountain had never announced.
+#: water-treatment job. `options` is narrowed to the fountain's own family: the
+#: litter list (`work_continue`, `dump_over`, ...) names cycles this device does
+#: not have. Before this existed a fountain's `work_start` published to a
+#: discovery topic the fountain had never announced.
 FOUNTAIN_W7H_EVENTS = [
     EntityDef(component="event", key="cleaning_event", name="Work Event",
               icon="mdi:water-sync",
-              options=["work_start", "add_water_over"]),
+              options=codes.mqtt_event_names(codes.KIND_CLEANING,
+                                             codes.FOUNTAIN_NEXT_GEN)),
     EntityDef(component="event", key="drinking_event", name="Drinking Event",
               icon="mdi:cup-water",
-              options=["drink_start", "drink_over"]),
+              options=codes.mqtt_event_names(codes.KIND_DRINKING,
+                                             codes.FOUNTAIN_NEXT_GEN)),
     EntityDef(component="event", key="error_event", name="Error Event",
               icon="mdi:alert",
-              options=["error_start", "error_over"]),
+              options=codes.mqtt_event_names(codes.KIND_ERROR,
+                                             codes.FOUNTAIN_NEXT_GEN)),
 ]

--- a/addon/petkit_local/ha/publisher.py
+++ b/addon/petkit_local/ha/publisher.py
@@ -35,6 +35,7 @@ from petkit_local.ha.entities.ble import get_ble_entities
 from petkit_local.ha.entities.pet import PET_SENSORS
 from petkit_local.ha.discovery import build_discovery_payload, discovery_topic
 from petkit_local.devices.state_parsers import apply_consumable_state
+from petkit_local.events.normalize import MQTT_ENVELOPE_KEYS
 from petkit_local.ha.commands import LOCAL_DEFAULTS
 from petkit_local.utils.jsonio import read_bytes
 
@@ -329,13 +330,25 @@ class HAPublisher:
 
         A retained event would re-fire on every HA restart, which for a toilet
         visit or an error would look like the thing just happened again.
+
+        HA's event platform reads the payload as a JSON object: `event_type`
+        is validated against the discovery config's `event_types`, and every
+        OTHER key becomes an attribute of the fired event, visible in the
+        logbook and stored by the recorder. So `attrs` should be the event's
+        decoded `content` (weight, error text, ...), never the raw MQTT
+        `params`: those carry the transport envelope, including `XDevice`, the
+        signed request credential. The envelope is stripped here as well —
+        same rule as merging `params` into `device.state`, enforced at the one
+        place the payload is built.
         """
         if not self._client or not self._connected:
             return
         topic = f"petkit-local/{device.petkit_id}/event/{entity_suffix}"
-        doc = {"event_type": event_type}
-        if attrs:
-            doc.update(attrs)
+        doc = {k: v for k, v in (attrs or {}).items()
+               if k not in MQTT_ENVELOPE_KEYS}
+        # Written last: a device-supplied content key named `event_type` must
+        # not override the type HA validates.
+        doc["event_type"] = event_type
         await self._emit(topic, json.dumps(doc), retain=False)
 
     async def publish_media_ready(self, device: Device, media: dict | None) -> None:

--- a/addon/petkit_local/mqtt/bridge.py
+++ b/addon/petkit_local/mqtt/bridge.py
@@ -510,10 +510,15 @@ class MQTTBridge:
                     await self._ha_publisher.publish_pet_discovery(pet)
                     await self._ha_publisher.publish_pet_state(pet, self._event_store)
 
-        # Fire the matching HA event entity (momentary).
+        # Fire the matching HA event entity (momentary). `content`, not
+        # `params`: everything in the payload besides `event_type` becomes an
+        # attribute of the HA event, and `params` is the transport envelope —
+        # `XDevice` (the signed request credential) and the full state
+        # snapshot have no business in HA's logbook. The HTTP path
+        # (http/handlers/stubs.py) passes the same decoded content.
         entity_suffix = entity_for_event(event_type, device.device_type)
         if entity_suffix and self._ha_publisher:
-            await self._ha_publisher.publish_event(device, entity_suffix, event_type, params)
+            await self._ha_publisher.publish_event(device, entity_suffix, event_type, content)
 
         if self._ha_publisher:
             await self._ha_publisher.publish_state(device)

--- a/addon/tests/test_bridge_events.py
+++ b/addon/tests/test_bridge_events.py
@@ -121,3 +121,25 @@ async def test_the_request_credential_never_lands_in_device_state():
     # The telemetry beside it still applies, or this would be a silent regression.
     assert device.state["sandPercent"] == 40
     assert device.state["totalTime"] == 900
+
+
+async def test_ha_event_fires_with_content_not_transport_envelope():
+    """Everything in the event payload besides `event_type` becomes an HA
+    event attribute, so the bridge hands publish_event the decoded CONTENT.
+    Passing raw `params` shipped the transport envelope — `XDevice`, the
+    signed request credential, plus the full state snapshot — into HA's
+    logbook and recorder."""
+    with tempfile.TemporaryDirectory() as tmp:
+        reg, dev, pub, store, hub, pet_registry, bridge = _setup(tmp)
+        await bridge._handle_event(dev, "clean_over", {
+            "params": {
+                "XDevice": "id=1&nonce=x&sign=y",
+                "event_id": "10000001_1785276736",
+                "timestamp": 1785276736,
+                "state": json.dumps({"sandPercent": 40}),
+                "content": json.dumps({"start_reason": 0, "result": 0}),
+            }
+        })
+        assert pub.events == [
+            (10, "cleaning_event", "clean_over", {"start_reason": 0, "result": 0}),
+        ]

--- a/addon/tests/test_discovery.py
+++ b/addon/tests/test_discovery.py
@@ -212,3 +212,20 @@ def test_litter_weight_is_published_in_the_unit_the_device_reports():
     # between the two is the tell that one of them is wrong.
     _, pet = next((e, p) for e, p in _build_all(d) if e.key == "pet_weight")
     assert pet["unit_of_measurement"] == p["unit_of_measurement"]
+
+
+def test_event_entity_payload_reaches_ha_unwrapped():
+    """HA's MQTT event platform renders value_template FIRST and then requires
+    the result to still be a JSON object carrying `event_type` (extra keys
+    become the fired event's attributes). The old template here extracted the
+    bare string, so HA rejected every event — "No valid JSON event payload
+    detected, value after processing payload 'clean_over'" — and the entities
+    never left `unknown`. The publisher already sends exactly the JSON HA
+    wants, so the config must not template it at all."""
+    d = Device(device_type="t6", petkit_id=7, serial_number="SN")
+    events = [(e, p) for e, p in _build_all(d) if e.component == "event"]
+    assert events, "a T6 announces event entities"
+    for e, p in events:
+        assert "value_template" not in p
+        assert p["state_topic"] == f"petkit-local/7/event/{e.unique_id_suffix}"
+        assert p["event_types"] == e.options

--- a/addon/tests/test_entities.py
+++ b/addon/tests/test_entities.py
@@ -212,3 +212,31 @@ def test_state_topic_list_is_not_shared_between_calls():
     first = get_mqtt_state_topics(d)
     first.clear()
     assert get_mqtt_state_topics(d), "topic list must be rebuilt per call"
+
+
+def test_event_entity_options_accept_every_event_the_device_can_fire():
+    """HA silently drops a fired event_type the discovery config did not
+    declare. The firing side is `normalize.entity_for_event` (codes table ->
+    kind -> entity key); the accepting side is the entity's `options`. This
+    pins the two together: every MQTT event name that fires an entity a
+    device announces must be in that entity's list. A real T6's `light_over`
+    was dropped exactly this way — it fires `cleaning_event`, whose
+    hand-written list stopped at the cycles a T3 has."""
+    from petkit_local.events import codes
+    from petkit_local.events.normalize import KIND_TO_ENTITY
+
+    for dt in DEVICE_TYPES:
+        d = Device(device_type=dt, petkit_id=1, serial_number="SN")
+        events = {e.key: e for e in get_entities_for_device(d)
+                  if e.component == "event"}
+        for name, code in codes.MQTT_EVENT_TOPICS.items():
+            if dt not in code.families:
+                continue
+            key = KIND_TO_ENTITY.get(code.kind)
+            if key is None or key not in events:
+                # A kind no entity listens to (pet/motion/system), or an
+                # entity this category does not announce: nothing fires, so
+                # there is nothing to accept.
+                continue
+            assert name in events[key].options, (
+                f"{dt}: '{name}' fires '{key}' but its event_types omit it")

--- a/addon/tests/test_publisher_events.py
+++ b/addon/tests/test_publisher_events.py
@@ -1,0 +1,58 @@
+"""HAPublisher.publish_event — the payload contract HA's event platform holds.
+
+HA parses the payload as a JSON OBJECT: `event_type` is validated against the
+discovery config's `event_types`, and every other key becomes an attribute of
+the fired event, visible in the logbook and stored by the recorder. That is
+also why the discovery config carries no value_template (see ha/discovery.py):
+HA renders the template first and then requires the result to still be JSON,
+so extracting the string made HA reject every event.
+"""
+import json
+
+from petkit_local.devices.registry import DeviceRegistry
+from petkit_local.ha.publisher import HAPublisher
+from tests._fakes import FakeMqttClient
+
+
+def _setup():
+    reg = DeviceRegistry()
+    dev = reg.get_or_create(petkit_id=1, device_type="t6", serial_number="SN")
+    pub = HAPublisher(reg, {})
+    pub._client = FakeMqttClient()
+    pub._connected = True
+    return dev, pub
+
+
+async def test_event_payload_is_json_carrying_event_type():
+    dev, pub = _setup()
+    await pub.publish_event(dev, "cleaning_event", "clean_over")
+    [(topic, payload, kw)] = pub._client.published
+    assert topic == "petkit-local/1/event/cleaning_event"
+    assert json.loads(payload) == {"event_type": "clean_over"}
+    # Momentary: a retained event would re-fire on every HA restart.
+    assert kw == {"retain": False}
+
+
+async def test_event_attrs_become_attributes_and_envelope_is_stripped():
+    dev, pub = _setup()
+    await pub.publish_event(dev, "toilet_event", "pet_out", {
+        "pet_weight": 4200,
+        # The transport envelope must never reach HA — `XDevice` is the signed
+        # request credential and `state` the full snapshot. Same rule as
+        # merging `params` into `device.state` (events/normalize.py).
+        "XDevice": "id=1&nonce=x&sign=y",
+        "event_id": "10000001_1785276736",
+        "timestamp": 1785276736,
+        "content": "{}",
+        "state": "{}",
+    })
+    [(_, payload, _)] = pub._client.published
+    assert json.loads(payload) == {"event_type": "pet_out", "pet_weight": 4200}
+
+
+async def test_device_content_cannot_override_event_type():
+    dev, pub = _setup()
+    await pub.publish_event(dev, "cleaning_event", "clean_over",
+                            {"event_type": "spoofed"})
+    [(_, payload, _)] = pub._client.published
+    assert json.loads(payload)["event_type"] == "clean_over"


### PR DESCRIPTION
## What was broken

Every `event` entity has been stuck at `unknown` since the platform shipped — two independent rejections on the HA side:

1. **The discovery config templated the payload away.** HA's MQTT event platform renders `value_template` first and then requires the *result* to still be a JSON object carrying `event_type`. The config extracted the bare string, so HA logged

   ```
   No valid JSON event payload detected, value after processing payload 'clean_over' on topic petkit-local/12345678/event/cleaning_event
   ```

   and dropped every event. (The publisher has sent the right JSON since day one — the template unwrapped it.)

2. **The hand-written `event_types` lists lag the codes table**, and HA silently drops a fired type it was not told about. A real T6's `light_over` fires `cleaning_event`, whose list stopped at the cycles a T3 has; the W7H's newly-mapped `flush_over` / `water_change_over` likewise never reached its Work Event list.

## The fix

- **`ha/discovery.py`** — the event branch publishes no `value_template`; HA parses the payload JSON directly.
- **`mqtt/bridge.py`** — passes the decoded `content` (what the HTTP path already passes) instead of raw `params`. With the payload now actually parsed, every extra key becomes an attribute of the fired event in the logbook/recorder — and `params` is the transport envelope, `XDevice` (the signed request credential) included. `publish_event` additionally strips the envelope keys and writes `event_type` last, so device content can neither leak a credential into HA nor spoof the validated type.
- **`ha/entities/events.py`** — `options` is now derived from `codes.MQTT_EVENT_TOPICS` (kind × family, new helper `codes.mqtt_event_names`), the same table the firing side (`entity_for_event`) dispatches on; a new test pins firing and accepting together so the next added code cannot drift. Entity keys, names and icons are unchanged — no live entity is orphaned.

## Verified on hardware

T6 (Purobot Ultra, firmware 929) over MQTT, HA + Mosquitto:

- Wire payload after the fix:

  ```
  petkit-local/12345678/event/cleaning_event {"start_time": 1786620158, "from_clear": 0, "start_reason": 2, "result": 0, "err": "", "event_type": "light_over"}
  ```

- `event.…_cleaning_event` state moved to the event's timestamp, attributes carry the content fields and nothing else; no more MQTT-event warnings in the HA log. Both paired `light_over` reports were accepted — the type that was previously missing from `event_types` on top of the payload rejection.

`cd addon && pytest` — 1703 passed; `ruff check` clean.

## Known gap, deliberately unchanged

Over HTTP the numeric code string (e.g. `"10"`) is fired as the event_type, which the declared lists (semantic MQTT names) never contain, so an HTTP-reporting device's events are dropped exactly as before — one log line different. Naming each numeric code's semantic twin is codes-table work (grades and all); happy to do it as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
