### PR TITLE
Derive Food Low from hopper presence: a full hopper read as low

### DIFF
--- a/addon/petkit_local/devices/state_parsers.py
+++ b/addon/petkit_local/devices/state_parsers.py
@@ -160,6 +160,29 @@ def _extract_feeder_next_gen(body: dict[str, Any], state: dict[str, Any],
     _extract_sensor_block(body, state, FEEDER_HALLS)
 
 
+def _derive_food_low(state: dict[str, Any]) -> None:
+    """Turn the hopper-presence `food` into an explicit `foodLow` 0/1.
+
+    `food` is presence of food in the hopper, not a shortage flag: a live D4H
+    (fw 867) holds a steady 2 with a FULL hopper and reports 0 only when
+    nothing is detected -- transiently while food moves through during a
+    dispense, and for real once the hopper runs out. The shared "Food Low"
+    binary sensor used to read `food` through discovery's generic
+    truthy-is-ON template (`ha/discovery.py::_value_template`), so a full
+    hopper read as Food Low ON -- backwards. Deriving the flag here keeps the
+    raw `food` for the Hopper enum sensor and gives the problem sensor a
+    value that is 1 exactly when the device says nothing is there.
+
+    Gated on presence, the module's standing rule: a model that never sends
+    `food` (a D4SH says `food1`/`food2`) derives nothing. ONE helper called
+    from BOTH transports, for the reason spelled out on
+    `_extract_feeder_next_gen` -- today no MQTT table carries a singular
+    `food`, so the property/post call site is armed but idle until one does.
+    """
+    if "food" in state:
+        state["foodLow"] = 1 if to_float(state.get("food"), 2) == 0 else 0
+
+
 def _extract_presence_flags(body: dict[str, Any], state: dict[str, Any]) -> None:
     """Turn the presence-signalled fields into 0/1 in `state`.
 
@@ -491,6 +514,9 @@ def _parse_feeder(body: dict[str, Any], device_type: str = "") -> dict[str, Any]
     # Error sensor reads whatever the last transport to arrive had to say --
     # exactly the asymmetry this module's docstring calls the standard bug.
     _extract_error_flags(body, state, device_type)
+    # Explicit Food Low, derived from `food` presence -- see _derive_food_low
+    # for why the raw value cannot back a problem sensor directly.
+    _derive_food_low(state)
 
     feed_state = dig(body, "feedState", default=dig(body, "feed_state", default={}))
     if isinstance(feed_state, dict) and feed_state:
@@ -626,6 +652,7 @@ def normalize_property_params(device_type: str, params: dict[str, Any]) -> dict[
 
     _extract_fountain_w7h(params, flat, device_type)
     _extract_feeder_next_gen(params, flat, device_type)
+    _derive_food_low(flat)
     if device_type.lower() in LITTER_CAMERA_MODELS:
         _extract_sensor_block(params, flat, LITTER_CAMERA_HALLS)
 

--- a/addon/petkit_local/ha/entities/sensors.py
+++ b/addon/petkit_local/ha/entities/sensors.py
@@ -225,8 +225,12 @@ FEEDER_SENSORS = [
 ]
 
 FEEDER_BINARY_SENSORS = [
+    # `state.foodLow` is DERIVED (`state_parsers._derive_food_low`), never the
+    # raw `food`: `food` is presence -- a live D4H (fw 867) holds a steady 2
+    # with a full hopper -- and discovery's generic truthy-is-ON template read
+    # that as the problem being present, so a full hopper showed as Food Low.
     EntityDef(component="binary_sensor", key="food_low", name="Food Low",
-              value_path="state.food", device_class="problem", icon="mdi:food-drumstick-off"),
+              value_path="state.foodLow", device_class="problem", icon="mdi:food-drumstick-off"),
     EntityDef(component="binary_sensor", key="feeding", name="Feeding",
               value_path="state.feeding", device_class="running", icon="mdi:food"),
     EntityDef(component="binary_sensor", key="eating", name="Eating",
@@ -248,9 +252,9 @@ FEEDER_BINARY_SENSORS = [
 #: They must be a separate list, not shared-and-excluded: `model_excludes` filters
 #: only the family base, NOT `model_entities`, so excluding `hopper2_level` for a
 #: D4H (as the code used to) never actually removed it. A single-hopper feeder
-#: must simply not be GIVEN these — see `ha/categories.py`. A D4H is ASSUMED to
-#: report the singular `food` instead (shown by the family `food_low`); that is
-#: inference from the cloud model, unverified until a D4H is captured.
+#: must simply not be GIVEN these — see `ha/categories.py`. A D4H reports the
+#: singular `food` instead — CONFIRMED on a live D4H (fw 867): steady 2 with a
+#: full hopper, 0 when nothing is detected.
 #:
 #: 2 = has food and 0 = empty, reported by the D4SH owner, who never saw 1 in
 #: between. So this is not a percentage, and it is not a two-state either until
@@ -270,9 +274,10 @@ FEEDER_DUAL_HOPPER_SENSORS = [
 #: the dual `hopper1_level` with the "1" dropped and pointed at the singular
 #: `state.food` the rest of the feeder family uses.
 #:
-#: GUESSED: no D4H has ever reported here, so whether it sends `food` (like the
-#: single-hopper cloud model) or `food1` (like the D4SH it shares a `ctrl` with)
-#: is unverified. This bets on `food`. Same 0/2 enum as the dual sensors above.
+#: CONFIRMED on a live D4H (fw 867): it sends the singular `food` (like the
+#: single-hopper cloud model), not `food1` (like the D4SH it shares a `ctrl`
+#: with) — steady 2 with a full hopper, 0 when nothing is detected. Same 0/2
+#: enum as the dual sensors above.
 FEEDER_SINGLE_HOPPER_SENSORS = [
     EntityDef(component="sensor", key="hopper_level", name="Hopper",
               value_path="state.food", icon="mdi:silo",

--- a/addon/tests/test_entity_backing.py
+++ b/addon/tests/test_entity_backing.py
@@ -166,6 +166,13 @@ PASSTHROUGH_ATTESTED = {
     "bowl": "D4SH 867 ctrl 'recv feed start leftover set(-1)'; both reports in issue #2",
     "feeding": "D4SH 867 ctrl state builder; both reports in issue #2",
     "eating": "D4SH 867 ctrl state builder; both reports in issue #2",
+    # D4H (YumShare Solo). Settled the question the D4SH rows above left open:
+    # a single-hopper next-gen feeder sends the SINGULAR `food`, not `food1`.
+    # Observed on a live D4H (fw 867): steady 2 with a full hopper, 0 when
+    # nothing is detected (transiently during a dispense, for real when empty)
+    # -- which is also why `food_low` reads the derived `foodLow`, never the
+    # raw value (see state_parsers._derive_food_low).
+    "food": "live D4H 867 state reports: steady 2 full, 0 empty/dispensing",
     # Values whose PRESENCE is settled and whose meaning is not. That is a fine
     # reason to publish -- an owner can watch a number move -- and no reason at
     # all to name it something, which is why each of these entities carries the
@@ -198,11 +205,11 @@ PASSTHROUGH_UNVERIFIED = {
     "filterLeftDays", "lackWarning", "heatRealTemp", "drinkTime",
     "desiccantLeftDays", "batteryPower",
     # `bowl`, `feeding` and `eating` graduated to PASSTHROUGH_ATTESTED once a
-    # real D4SH sent all three. `food` and `weight` did not, and they are the
-    # interesting half: the same two reports carry `food1`/`food2` and no
-    # `food`, no `weight`. So these stay the reference integration's cloud-model
-    # names, and both are now excluded on the models we can actually check.
-    "food", "weight",
+    # real D4SH sent all three, and `food` followed when a live D4H did. That
+    # leaves `weight`: the same D4SH reports carry `food1`/`food2` and no
+    # `weight`, and no feeder has sent one -- so it stays the reference
+    # integration's cloud-model name, excluded on the models we can check.
+    "weight",
     "liquid", "battery", "temp",
 }
 
@@ -251,6 +258,7 @@ _SHARED_HELPERS = (
     state_parsers._extract_camel, state_parsers._extract_litter_nested,
     state_parsers._extract_consumable_days, state_parsers._extract_shared,
     state_parsers._extract_presence_flags, state_parsers._extract_error_flags,
+    state_parsers._derive_food_low,
     state_parsers._extract_fountain_w7h,
     state_parsers._extract_wifi_rssi, state_parsers._extract_work_mode,
     state_parsers._parse_content_field, state_parsers.normalize_property_params,

--- a/addon/tests/test_state_parsers.py
+++ b/addon/tests/test_state_parsers.py
@@ -386,6 +386,20 @@ def test_an_esp32_feeder_is_not_given_fields_its_hardware_never_sends():
         assert key not in flat, key
 
 
+def test_food_low_is_derived_from_presence_not_truthiness():
+    """`food` is presence: a live D4H (fw 867) holds a steady 2 with a FULL
+    hopper and reports 0 only when nothing is detected. The Food Low problem
+    sensor used to read the raw value through discovery's generic truthy-is-ON
+    template, so a full hopper read as Food Low ON — backwards. It now reads
+    the derived `foodLow`, which is 1 exactly when the device says empty."""
+    assert parse_state_report("d4h", {"food": 2})["foodLow"] == 0
+    assert parse_state_report("d4h", {"food": 0})["foodLow"] == 1
+    # No `food`, no verdict: a D4SH reports `food1`/`food2` and no singular
+    # `food`, so nothing may invent a flag for it — absence stays absent.
+    assert "foodLow" not in parse_state_report("d4sh", D4SH_STATE)
+    assert "foodLow" not in normalize_property_params("d4sh", D4SH_STATE)
+
+
 def test_the_device_ip_still_comes_out_of_the_other_string():
     """Everything downstream of the camera needs it — the stream URL and the
     whole Patchers tab go quiet without one."""


### PR DESCRIPTION
## What a real D4H shows

You finally get your D4H capture — I own a YumShare Solo (fw 867, id 300008810) that has been running this add-on's code since 1.6.0 (via a patched build, now on 2.1.0 upstream). Two things it settles:

1. **A D4H sends the SINGULAR `food`, not `food1`** — exactly what `FEEDER_SINGLE_HOPPER_SENSORS` bets on. The GUESSED notes can come down.
2. **`food` is presence, not a shortage flag.** Steady `2` with a full hopper; `0` only when nothing is detected — transiently while food moves through during a dispense, and for real once the hopper runs out. `1` never observed, matching what the D4SH owner reported for `food1`/`food2` in #2.

## The bug

`food_low` (device_class `problem`) reads `state.food` through discovery's generic truthy-is-ON template (`_value_template`: `'ON' if … else 'OFF'`) — so a FULL hopper (`food: 2`) renders Food Low **ON**, and an empty one OFF. Backwards on every model that sends `food`.

## The fix

- `state_parsers._derive_food_low`: presence-gated `foodLow` = 1 exactly when `food` says nothing is there (`to_float(…, 2) == 0`); `food_low` now reads `state.foodLow`. Entity key unchanged, so no live entities orphan.
- One helper called from BOTH transports per the module's standing rule — today no MQTT table carries a singular `food`, so the property/post call site is armed but idle until one does.
- A D4SH (`food1`/`food2`, no singular `food`) derives nothing; absence stays absent.
- `food` graduates PASSTHROUGH_UNVERIFIED → PASSTHROUGH_ATTESTED with the live-D4H evidence; the hopper-sensor GUESSED comments upgraded to confirmed.

## Tests

- `test_food_low_is_derived_from_presence_not_truthiness` — 2→0, 0→1, and no invented flag for the D4SH fixture on either transport.
- Full suite: 1698 passed, 1 skipped. `ruff check` clean.

Happy to provide raw captures from this D4H if useful — it is live and reporting daily.