### PR TITLE
K3 piggyback: extract battery/liquid from HTTP too (closes half of #21)

### DIFF
--- a/addon/petkit_local/http/handlers/stubs.py
+++ b/addon/petkit_local/http/handlers/stubs.py
@@ -32,6 +32,7 @@ from petkit_local.events.ingest import (
 from petkit_local.http.handlers._common import (
     device_id, no_device_response, request_device,
 )
+from petkit_local.mqtt.ble_relay import update_linked_k3
 from petkit_local.media.crypto import resolve_key_string as _get_aes_key
 from petkit_local.utils.capture import capture_record
 from petkit_local.web.api.sounds import sound_list_for_device
@@ -234,6 +235,14 @@ async def handle_event_report(request: web.Request) -> web.Response:
             await ha_publisher.publish_event(device, entity_suffix, row["event_type"], content)
         await ha_publisher.publish_state(device)
         await ha_publisher.publish_availability(device)
+        # Every event report from a T4 carries `battery`/`liquid`/`k3Id` in
+        # its embedded state — the ESP32's HTTP twin of the MQTT property/post
+        # piggyback. See `mqtt.ble_relay.update_linked_k3`.
+        if isinstance(state, dict):
+            k3 = update_linked_k3(device, state, request.app.get("ble_registry"))
+            if k3:
+                await ha_publisher.publish_ble_discovery(k3)
+                await ha_publisher.publish_ble_state(k3)
 
     return web.json_response({"result": "success"})
 

--- a/addon/petkit_local/main/wiring.py
+++ b/addon/petkit_local/main/wiring.py
@@ -28,6 +28,7 @@ from petkit_local.media.crypto import resolve_key_string
 from petkit_local.media.go2rtc import Go2rtc
 from petkit_local.media.retention import RetentionConfig
 from petkit_local.mqtt.bridge import MQTTBridge
+from petkit_local.mqtt.ble_relay import update_linked_k3
 from petkit_local.mqtt.upstream import (
     CREDENTIALS_FILENAME, UpstreamCredentials, UpstreamMQTT,
 )
@@ -124,8 +125,17 @@ class _LocalRepublisher:
             await client.publish(topic, payload)
 
 
-async def _on_state_report(ha_publisher: HAPublisher, device: Device, body: dict) -> None:
-    """Mirror a freshly parsed state report into HA.
+async def _on_state_report(ha_publisher: HAPublisher, ble_registry: BLERegistry | None,
+                           device: Device, body: dict) -> None:
+    """Mirror a freshly parsed state report into HA — parent AND any linked K3.
+
+    On an unpatched ESP32 (T4, D4, D3) the device only ever HTTP-heartbeats,
+    so its property/post never reaches the MQTT bridge and the K3 piggyback
+    lift on that path is a no-op. `dev_state_report` carries the identical
+    top-level `battery`/`liquid`/`k3Id` keys, so extracting them here is the
+    HTTP-side twin of `mqtt/bridge.py`'s property/post branch — mirrors the
+    "ONE helper called from BOTH transports" rule the feeder parser already
+    follows.
 
     Only installed when HA publishing is enabled; the HTTP handler
     treats a missing hook as "nothing to notify", so no other code
@@ -133,6 +143,10 @@ async def _on_state_report(ha_publisher: HAPublisher, device: Device, body: dict
     """
     await ha_publisher.publish_state(device)
     await ha_publisher.publish_availability(device)
+    k3 = update_linked_k3(device, body, ble_registry)
+    if k3:
+        await ha_publisher.publish_ble_discovery(k3)
+        await ha_publisher.publish_ble_state(k3)
 
 
 async def _on_signup(ha_publisher: HAPublisher | None, device: Device) -> None:
@@ -237,7 +251,7 @@ def build_services(config: Config, args: argparse.Namespace) -> Services:
     app[BACKGROUND_TASKS] = []
 
     if ha_publisher:
-        app["on_state_report"] = partial(_on_state_report, ha_publisher)
+        app["on_state_report"] = partial(_on_state_report, ha_publisher, ble_registry)
 
     app["on_signup"] = partial(_on_signup, ha_publisher)
     app["on_device_seen"] = partial(_on_device_seen, ha_publisher)

--- a/addon/petkit_local/mqtt/ble_relay.py
+++ b/addon/petkit_local/mqtt/ble_relay.py
@@ -40,6 +40,45 @@ log = logging.getLogger(__name__)
 BLE_SESSION_HOLD_SECONDS = 30
 
 
+def update_linked_k3(device: "Device", params: dict,
+                     ble_registry: "BLERegistry | None") -> "BLEDevice | None":
+    """Merge K3 consumable fields piggybacked on the parent's state report.
+
+    Transport-agnostic: the K3 spray is BLE-only and never posts anything of
+    its own, so its `battery` and `liquid` ride along on the parent litter
+    box's continuous state — MQTT `property/post`, HTTP `dev_state_report`,
+    and the embedded `state` block of every `dev_event_report`. All three
+    carry the same top-level keys, so ONE extractor covers every transport,
+    for the reason `_extract_feeder_next_gen` records: a mapping added to
+    only one of them works on whichever frames happen to carry it and
+    silently does nothing on the other.
+
+    Returns:
+        The K3 BLEDevice if anything changed (the caller re-publishes it to
+        HA), else None.
+    """
+    if not ble_registry:
+        return None
+    k3 = ble_registry.get_linked_k3(device.petkit_id)
+    if not k3:
+        return None
+
+    updated = False
+    if "battery" in params:
+        k3.state.setdefault("consumables", {})["battery"] = params["battery"]
+        updated = True
+    if "liquid" in params:
+        k3.state.setdefault("consumables", {})["liquid"] = params["liquid"]
+        updated = True
+
+    if not updated:
+        return None
+    ble_registry.mark_dirty()
+    log.info("Updated K3 (id=%d) from parent device %d: battery=%s liquid=%s",
+             k3.petkit_id, device.petkit_id,
+             params.get("battery", "?"), params.get("liquid", "?"))
+    return k3
+
 class BLERelay:
     """Reads and writes BLE accessories through their parent's MQTT session.
 
@@ -246,36 +285,11 @@ class BLERelay:
     def _update_linked_k3(self, device: Device, params: dict) -> BLEDevice | None:
         """Merge K3 consumable fields piggybacked on the parent's property post.
 
-        The K3 spray is BLE-only and never posts anything itself: its
-        battery and liquid level ride along in the parent litter box's own
-        property post, which is why they are picked out here rather than in
-        `_handle_ble_response`.
-
-        Returns:
-            The K3 BLEDevice if anything changed (the caller re-publishes it to
-            HA), else None.
+        Thin wrapper around :func:`update_linked_k3` — every transport now
+        reaches the same helper, this is only kept for the MQTT call site's
+        readability. See the free function for the full contract.
         """
-        if not self._ble_registry:
-            return None
-        k3 = self._ble_registry.get_linked_k3(device.petkit_id)
-        if not k3:
-            return None
-
-        updated = False
-        if "battery" in params:
-            k3.state.setdefault("consumables", {})["battery"] = params["battery"]
-            updated = True
-        if "liquid" in params:
-            k3.state.setdefault("consumables", {})["liquid"] = params["liquid"]
-            updated = True
-
-        if not updated:
-            return None
-        self._ble_registry.mark_dirty()
-        log.info("Updated K3 (id=%d) from parent device %d: battery=%s liquid=%s",
-                 k3.petkit_id, device.petkit_id,
-                 params.get("battery", "?"), params.get("liquid", "?"))
-        return k3
+        return update_linked_k3(device, params, self._ble_registry)
 
     async def _handle_ble_response(self, device: Device, params: dict) -> None:
         """Apply one relayed BLE frame to the accessory it came from.

--- a/addon/tests/test_http_k3.py
+++ b/addon/tests/test_http_k3.py
@@ -1,0 +1,163 @@
+"""HTTP-side K3 piggyback: a T4 (unpatchable ESP32) never talks MQTT, so its
+`property/post` — and with it the K3's `battery`/`liquid` that ride along —
+never reaches the bridge. `dev_state_report` and `dev_event_report` carry the
+same top-level keys, so the same helper must fire on both HTTP paths for a
+linked K3 to publish anything to Home Assistant.
+
+Live evidence (T4 firmware 1.652, 2026-08-16): every one of 24 state reports
+and 26 event reports carried `k3Id`, `liquid`, `battery` at the top of the
+`state` object — same shape the MQTT bridge already extracts, different
+transport.
+"""
+from __future__ import annotations
+
+import json
+from urllib.parse import urlencode
+
+from aiohttp.test_utils import TestClient, TestServer
+
+from petkit_local.devices.ble import BLERegistry
+from petkit_local.devices.registry import DeviceRegistry
+from petkit_local.events.store import EventStore
+from petkit_local.http.server import create_app
+from petkit_local.mqtt.ble_relay import update_linked_k3
+
+CONFIG = {
+    "api_url": "http://server/6/",
+    "mqtt_port": 1883,
+    "proxy_mode": False,
+    "proxy_upstream": "",
+    "proxy_block_run_cmd": True,
+    # capture writes to disk; keep it off here.
+    "capture": False,
+}
+
+# The specific number does not matter, only that it resolves to the parent the
+# K3 is linked to.
+HDR = {"X-Device": "id=100050447&sn=SN"}
+
+
+class _FakePublisher:
+    def __init__(self) -> None:
+        self.states: list[int] = []
+        self.ble_states: list[int] = []
+        self.ble_discovery: list[int] = []
+
+    async def publish_state(self, device):
+        self.states.append(device.petkit_id)
+
+    async def publish_availability(self, device):
+        pass
+
+    async def publish_ble_discovery(self, ble_dev):
+        self.ble_discovery.append(ble_dev.petkit_id)
+
+    async def publish_ble_state(self, ble_dev):
+        self.ble_states.append(ble_dev.petkit_id)
+
+    async def publish_event(self, *_a, **_k):
+        pass
+
+
+def _setup():
+    reg = DeviceRegistry()
+    reg.get_or_create(petkit_id=100050447, device_type="t4", serial_number="SN")
+    ble = BLERegistry()
+    ble.register(ble_type="k3", petkit_id=555, mac="AA:BB", link_with=100050447)
+    return reg, ble, _FakePublisher()
+
+
+async def _client(reg, ble, pub) -> TestClient:
+    app = create_app(reg, dict(CONFIG))
+    app["ble_registry"] = ble
+    app["ha_publisher"] = pub
+    app["event_store"] = EventStore(":memory:")
+    # Mirror wiring.py: the HTTP handler treats a missing hook as no-op, so
+    # installing exactly the same closure keeps behaviour production-shaped.
+    async def on_state_report(device, body):
+        await pub.publish_state(device)
+        await pub.publish_availability(device)
+        k3 = update_linked_k3(device, body, ble)
+        if k3:
+            await pub.publish_ble_discovery(k3)
+            await pub.publish_ble_state(k3)
+    app["on_state_report"] = on_state_report
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+# --- the helper is the whole point: assert it directly first ---------------
+
+def test_helper_updates_battery_and_liquid_from_top_level_state():
+    reg, ble, _pub = _setup()
+    dev = reg.get(100050447)
+    changed = update_linked_k3(dev, {"battery": 88, "liquid": 60}, ble)
+    assert changed is not None and changed.petkit_id == 555
+    assert ble.get(555).state["consumables"] == {"battery": 88, "liquid": 60}
+
+
+def test_helper_returns_none_without_a_linked_k3():
+    reg = DeviceRegistry()
+    reg.get_or_create(petkit_id=100050447, device_type="t4", serial_number="SN")
+    dev = reg.get(100050447)
+    assert update_linked_k3(dev, {"battery": 88, "liquid": 60}, BLERegistry()) is None
+
+
+def test_helper_returns_none_when_neither_key_is_present():
+    """`sandType` is present in every real state block; only battery/liquid
+    should trigger a K3 update."""
+    reg, ble, _pub = _setup()
+    assert update_linked_k3(reg.get(100050447), {"sandType": 1}, ble) is None
+
+
+# --- the HTTP paths: dev_state_report and dev_event_report -----------------
+
+async def test_state_report_updates_linked_k3_from_http():
+    reg, ble, pub = _setup()
+    client = await _client(reg, ble, pub)
+    try:
+        # Verbatim shape from a live T4 (2026-08-16 capture, trimmed).
+        state = {
+            "litter": {"weight": 1944, "percent": 0, "sandType": 0},
+            "k3Id": 555, "liquid": 60, "battery": 88,
+        }
+        r = await client.post(
+            "/6/t4/dev_state_report",
+            headers={**HDR, "Content-Type": "application/x-www-form-urlencoded"},
+            data=f"state={json.dumps(state)}",
+        )
+        assert r.status == 200
+        assert ble.get(555).state["consumables"] == {"battery": 88, "liquid": 60}
+        assert 555 in pub.ble_states
+        assert 555 in pub.ble_discovery
+    finally:
+        await client.close()
+
+
+async def test_event_report_state_block_updates_linked_k3():
+    reg, ble, pub = _setup()
+    client = await _client(reg, ble, pub)
+    try:
+        # A cleaning event (eventType 5) — every real T4 event report carries
+        # this exact state envelope; the wire form is x-www-form-urlencoded.
+        form = {
+            "eventType": "5",
+            "event_id": "100050447_1786877430",
+            "timestamp": "1786877529",
+            "content": json.dumps({"result": 0, "err": None}),
+            "state": json.dumps({
+                "litter": {"weight": 1943, "percent": 0, "sandType": 0},
+                "k3Id": 555, "liquid": 42, "battery": 77,
+            }),
+        }
+        r = await client.post(
+            "/6/t4/dev_event_report",
+            headers={**HDR, "Content-Type": "application/x-www-form-urlencoded"},
+            data=urlencode(form),
+        )
+        assert r.status == 200
+        assert ble.get(555).state["consumables"] == {"battery": 77, "liquid": 42}
+        assert 555 in pub.ble_states
+    finally:
+        await client.close()


### PR DESCRIPTION
## Background

Issue #21 reports that a T4's linked K3 stays `unknown` in HA: `dev_state_report (HTTP) never forwards them to the linked K3`. Confirmed independently on my T4 (fw 1.652, id 100050447) — I filed the reproduction earlier in that thread's tone, and this PR is the fix for the K3 half of it.

## What upstream does today

`mqtt/bridge.py::_update_linked_k3` lifts `battery`/`liquid` off the parent's MQTT `property/post` params. Comment on it is exact: *"The K3 spray is BLE-only and never posts anything itself: its battery and liquid level ride along in the parent litter box's own property post, which is why they are picked out here rather than in `_handle_ble_response`."*

## What's missing

An **unpatched ESP32 parent** (T4, D4, D3 — no MQTT-TLS bypass available) HTTP-heartbeats only. Its `property/post` never reaches the bridge, so `_update_linked_k3` is a permanent no-op. But `dev_state_report` **and every `dev_event_report`'s embedded `state` block** carry the identical top-level `battery`/`liquid`/`k3Id` keys.

Live evidence from my T4:
- 24 `dev_state_report` bodies, every one with `k3Id: 100059530, liquid: 83, battery: 90` at the top of `state`
- 26 `dev_event_report` bodies (event types 3/4/5/8/9/10/12/14/15/16/20), every one carries the same fields in the embedded `state` block

## The change

Same mirror-both-transports rule your own `_extract_feeder_next_gen` already follows ("a mapping added to only one of them works on whichever frames happen to carry it and silently does nothing on the other"):

1. Extract `_update_linked_k3` from `BLERelay` into a module-level `update_linked_k3(device, params, ble_registry)`. The class method stays as a thin wrapper so the existing MQTT call site + your test in `test_bridge.py` are unchanged.
2. `main/wiring.py::_on_state_report` takes `ble_registry` and calls the helper after the HA state publish. Only installed when HA is enabled, matching the existing no-op-if-missing hook contract.
3. `http/handlers/stubs.py::handle_event_report` calls the helper on the embedded `state` block after `apply_state_snapshot`.

## Not addressed here — deliberately

The CTW3 relay half of #21. I ran 60+ minutes of proxy-mode traffic through my live T4 with a paired CTW3 and manually queued `thing.service.connect` via the heartbeat: **the T4 never posts a single `ble_response` frame over HTTP** — not to us, not to real PetKit. The frames appear to be strictly MQTT-topic-scoped in the ESP32 firmware. Without patched firmware there is no HTTP path to plumb into, so the CTW3 half stays out of reach.

## Testing

- 5 new tests in `tests/test_http_k3.py` — helper unit tests + both HTTP endpoints (state_report + event_report) with a real `create_app` client and BLE registry.
- Existing MQTT-side regression `test_property_updates_linked_k3_and_publishes` continues to pass via the thin method wrapper.
- Full suite: **1702 passed, 1 skipped**. `ruff check` clean.
- **Verified live** on my T4: after deploying the patched build the log fires `Updated K3 (id=100059530) from parent device 100050447: battery=90 liquid=83` on the very next state report, and the HA entities hold values.