### PR TITLE
Dispense single-hopper D4H/D4H2 scheduled feeds with the `a` amount key

### DIFF
--- a/addon/petkit_local/events/codes.py
+++ b/addon/petkit_local/events/codes.py
@@ -940,6 +940,17 @@ SCHEDULE_TYPES: dict[int, str] = {
 #: time=%d,repeats=%d` — so `a1`/`a2` are the per-hopper portions, the same pair
 #: a `feed_realtime` carries on this model, and `re` is the group's weekdays.
 #:
+#: The single-hopper D4H/D4H2 carries `a` instead — one amount, no per-hopper
+#: split — exactly as it reads `amount` where the Dual-Hopper reads
+#: `amount1`/`amount2` from a `feed_realtime` (`utils/const.py`,
+#: `ha/commands.py::_feed`). Confirmed on a D4H2 (867): a cloud-made schedule
+#: with `a` in both `it[]` and `latest[]` dispensed, while `a1`/`a2` ran the
+#: cycle and put out nothing — `real_amount: 0, err_code: 8` (FEED_RESULT[8],
+#: "failed (nothing dispensed)"). So the amount key is
+#: PER MODEL and never both: `a` on a single hopper, `a1`/`a2` on a dual. The
+#: two never convert — `a` is the device's own unit (÷ a config constant, like
+#: realtime `amount`), not the portions a hopper counts.
+#:
 #: `it` arrived POPULATED on 2026-08-12 — 21 proxied `dev_feed_get` responses
 #: from the real cloud to a D4SH with meals set. They settle what the earlier
 #: firmware read could not:
@@ -957,7 +968,7 @@ SCHEDULE_TYPES: dict[int, str] = {
 #:     `it` anyway, because that is what the real cloud sends (keys in
 #:     alphabetical order) and there is no reason to hand the device a payload
 #:     a shape narrower than the one it knows.
-FEED_SCHEDULE_ITEM_KEYS = ("id", "t", "a1", "a2")
+FEED_SCHEDULE_ITEM_KEYS = ("id", "t", "a", "a1", "a2")
 
 #: The weekday numbering PetKit uses everywhere a schedule names days:
 #: `schedule[].repeats`, `cameraMultiRange[].rpt` and their siblings.

--- a/addon/petkit_local/http/handlers/feed.py
+++ b/addon/petkit_local/http/handlers/feed.py
@@ -40,6 +40,22 @@ _EMPTY_GROUP = {"re": "1,2,3,4,5,6,7", "it": [], "itemJsonString": "[]"}
 _ITEM_JSON = dict(separators=(",", ":"), sort_keys=True)
 
 
+def _amount_fields(src: dict) -> dict:
+    """The meal's dispensed amount, in whichever shape the source carries.
+
+    A single-hopper D4H/D4H2 meal holds one ``a``; a Dual-Hopper holds
+    ``a1``/``a2`` (``events/codes.py::FEED_SCHEDULE_ITEM_KEYS``). ``latest[]``
+    must repeat the SAME key the firmware reads: a D4H fired from a ``latest``
+    entry carrying ``a1``/``a2`` runs the feed cycle and dispenses nothing
+    (``real_amount: 0, err_code: 8``, the mirror of issue #2). The two shapes
+    never convert — ``a`` is the device's own unit, not the portions a hopper
+    counts — so this copies the one present rather than deriving the other.
+    """
+    if "a" in src:
+        return {"a": src["a"]}
+    return {"a1": src.get("a1", 0), "a2": src.get("a2", 0)}
+
+
 def _local_midnight(now: float, day_offset: int) -> float:
     """Local midnight ``day_offset`` days after the day containing ``now``.
 
@@ -84,7 +100,10 @@ def _build_latest(feed: dict, now: float) -> list[dict]:
 
     Both kinds land here — ``s_`` instances of recurring meals and ``d_``
     deferred feeds — sorted by countdown. ``t`` is ``floor(fire - now)``,
-    which is why the cloud's countdowns keep landing on :59.
+    which is why the cloud's countdowns keep landing on :59. Each entry carries
+    the amount forward in the source meal's own shape (``_amount_fields``): ``a``
+    for a single-hopper D4H, ``a1``/``a2`` for a Dual-Hopper. The firmware fires
+    from ``latest``, so getting that key wrong is a feed that dispenses nothing.
 
     The two-day window is what 21 captures show: meals four days out never
     appeared, a deferred feed 27 hours out (tomorrow evening) always did. A
@@ -114,8 +133,7 @@ def _build_latest(feed: dict, now: float) -> list[dict]:
                 result.append({
                     "id": f"s_{date_str}_{t_secs}",
                     "t": int(fire - now),
-                    "a1": item.get("a1", 0),
-                    "a2": item.get("a2", 0),
+                    **_amount_fields(item),
                 })
 
     deferred = feed.get("deferred") or []
@@ -130,8 +148,7 @@ def _build_latest(feed: dict, now: float) -> list[dict]:
         result.append({
             "id": d.get("id", ""),
             "t": int(fire_at - now),
-            "a1": d.get("a1", 0),
-            "a2": d.get("a2", 0),
+            **_amount_fields(d),
         })
     if len(remaining) != len(deferred):
         feed["deferred"] = remaining

--- a/addon/petkit_local/web/api/schedules.py
+++ b/addon/petkit_local/web/api/schedules.py
@@ -19,6 +19,7 @@ from petkit_local.devices.base import encode_multi_range
 from petkit_local.ha.commands import PROPERTY_SET_SUFFIX, make_mqtt_property_set
 from petkit_local.http.handlers.feed import _build_latest, _compute_next_tick
 from petkit_local.utils.coerce import to_int
+from petkit_local.utils.const import DEVICE_TYPES_FEEDER_DUAL
 from petkit_local.web.api._common import _deliver, _device_or_404, _json_body
 
 
@@ -128,15 +129,48 @@ def _clean_point_list(value: Any) -> list[dict[str, Any]] | None:
     return cleaned
 
 
-def _clean_feed_schedule(value: Any) -> dict[str, Any] | None:
+def _clean_meal_amounts(meal: dict, dual: bool) -> dict[str, Any] | None:
+    """A meal's dispensed amount, validated, in the model's own shape.
+
+    A Dual-Hopper carries `a1`/`a2`, one per hopper (`a2` defaults 0); a
+    single-hopper D4H/D4H2 carries a lone `a`, which is the field its
+    `pk_schmg_parse_schedule` reads — sent `a1`/`a2` it dispenses nothing
+    (`err_code: 8`, the mirror of the Dual-Hopper's issue #2). Which key a
+    feeder reads is per model, exactly as `feed_realtime` is (`ha/commands.py::
+    _feed`), and the two amounts never convert: `a` is the device's own unit,
+    not the portions a hopper counts.
+
+    For a single hopper a legacy `a1` is accepted as `a` — a schedule the
+    dual-only editor saved before this split is read, not silently emptied —
+    but never the other way. All are a single byte on the device, so 0..255.
+    """
+    if dual:
+        first = to_int(meal.get("a1"), None)
+        second = to_int(meal.get("a2"), 0)
+        if first is None or second is None:
+            return None
+        if not (0 <= first <= 255 and 0 <= second <= 255):
+            return None
+        return {"a1": first, "a2": second}
+    amount = to_int(meal.get("a"), None)
+    if amount is None:
+        amount = to_int(meal.get("a1"), None)  # legacy dual-only editor save
+    if amount is None or not 0 <= amount <= 255:
+        return None
+    return {"a": amount}
+
+
+def _clean_feed_schedule(value: Any, dual: bool) -> dict[str, Any] | None:
     """`{schedule: [{re, it, itemJsonString}], nextTick, latest}` — the feeder's.
 
     The shape comes from a D4SH 867 `ctrl` (`pk_schmg_parse_schedule`), which
-    reads `re` and `it` per group and `id`/`t`/`a1`/`a2` per meal; see
-    `events/codes.py::FEED_SCHEDULE_ITEM_KEYS`. Unlike every other schedule
-    here, a meal's `t` counts SECONDS since local midnight — the cloud's
-    `n_46560` fires at 12:56:00 (D4SH capture, 2026-08-12) — and the id is the
-    cloud's `n_<seconds>` scheme, regenerated whenever a client sends an int.
+    reads `re` and `it` per group and `id`/`t` per meal, then the amount in the
+    model's own key: `a1`/`a2` on a Dual-Hopper, a lone `a` on the single-hopper
+    D4H/D4H2 (`dual` selects which; see `events/codes.py::FEED_SCHEDULE_ITEM_KEYS`
+    and `_clean_meal_amounts`). Unlike every other schedule here, a meal's `t`
+    counts SECONDS since local midnight — the cloud's `n_46560` fires at 12:56:00
+    (D4SH capture, 2026-08-12) — and the id is the cloud's `n_<seconds>` scheme,
+    regenerated whenever a client sends an int.
 
     `itemJsonString` is rebuilt from `it` rather than trusted: the real cloud
     sends both, they are the same list twice, and two copies of one value in one
@@ -169,19 +203,15 @@ def _clean_feed_schedule(value: Any) -> dict[str, Any] | None:
             if not isinstance(meal, dict):
                 return None
             second_of_day = to_int(meal.get("t"), None)
-            first = to_int(meal.get("a1"), None)
-            second = to_int(meal.get("a2"), 0)
-            if second_of_day is None or first is None or second is None:
+            if second_of_day is None or not 0 <= second_of_day < DAY_SECONDS:
                 return None
-            if not 0 <= second_of_day < DAY_SECONDS:
-                return None
-            if not (0 <= first <= 255 and 0 <= second <= 255):
+            amounts = _clean_meal_amounts(meal, dual)
+            if amounts is None:
                 return None
             raw_id = meal.get("id")
             if not isinstance(raw_id, str) or not raw_id:
                 raw_id = f"n_{second_of_day}"
-            meals.append(
-                {"id": raw_id, "t": second_of_day, "a1": first, "a2": second})
+            meals.append({"id": raw_id, "t": second_of_day, **amounts})
 
         groups.append({
             "re": ",".join(str(d) for d in sorted(set(days))),
@@ -231,7 +261,8 @@ async def api_save_schedule(request: web.Request) -> web.Response:
     raw = body.get("value")
 
     if kind == "feed":
-        feed = _clean_feed_schedule(raw)
+        dual = d.device_type.lower() in DEVICE_TYPES_FEEDER_DUAL
+        feed = _clean_feed_schedule(raw, dual)
         if feed is None:
             return web.json_response({"error": "not a valid feeding schedule"}, status=400)
         d.config["feed_schedule"] = feed
@@ -274,8 +305,10 @@ async def api_deferred_feed(request: web.Request) -> web.Response:
     """Add or list deferred (one-off) feeds for a feeder.
 
     POST ``{"date": "2026-08-13", "time": "17:05", "a1": 0, "a2": 1}``
-    adds a deferred feed. GET lists pending ones. DELETE with ``{sound_id}``
-    in path removes one.
+    (Dual-Hopper) or ``{..., "a": 20}`` (single-hopper D4H/D4H2) adds a deferred
+    feed. GET lists pending ones. DELETE with ``{sound_id}`` in path removes one.
+    The amount is stored in the model's own key so the feed actually dispenses
+    (`_clean_meal_amounts`); a legacy `a1` is read as `a` on a single hopper.
 
     The device picks this up on its next ``dev_feed_get`` poll, which the
     heartbeat ``feed_get:1`` command triggers immediately.
@@ -306,8 +339,10 @@ async def api_deferred_feed(request: web.Request) -> web.Response:
     body = await _json_body(request)
     date_str = body.get("date", "")
     time_str = body.get("time", "")
-    a1 = to_int(body.get("a1"), 0)
-    a2 = to_int(body.get("a2"), 0)
+    if d.device_type.lower() in DEVICE_TYPES_FEEDER_DUAL:
+        amounts = {"a1": to_int(body.get("a1"), 0), "a2": to_int(body.get("a2"), 0)}
+    else:
+        amounts = {"a": to_int(body.get("a", body.get("a1")), 0)}
 
     try:
         dt = datetime.datetime.strptime(f"{date_str} {time_str}", "%Y-%m-%d %H:%M")
@@ -323,7 +358,7 @@ async def api_deferred_feed(request: web.Request) -> web.Response:
     secs_since_midnight = dt.hour * 3600 + dt.minute * 60 + dt.second
     feed_id = f"d_{dt.strftime('%Y%m%d')}_{secs_since_midnight}"
 
-    entry = {"id": feed_id, "a1": a1, "a2": a2, "fire_at": fire_at}
+    entry = {"id": feed_id, **amounts, "fire_at": fire_at}
     deferred.append(entry)
     reg.save()
 

--- a/addon/petkit_local/web/static/js/schedules.js
+++ b/addon/petkit_local/web/static/js/schedules.js
@@ -166,9 +166,11 @@ function renderWeeklyEditor(id, t, value) {
 }
 
 // A feeder's meals. Groups of them share weekdays, which is what `re` is on the
-// group and `it` is the meals inside it; each meal is `{id, t, a1, a2}`, read
-// out of a D4SH `ctrl` (see events/codes.py::FEED_SCHEDULE_ITEM_KEYS). `a2` is
-// the second hopper and only a Dual-Hopper has one.
+// group and `it` is the meals inside it. The amount key is per model, read out
+// of a `ctrl` (see events/codes.py::FEED_SCHEDULE_ITEM_KEYS): a Dual-Hopper meal
+// is `{id, t, a1, a2}`, one portion per hopper (`t.dual`); a single-hopper
+// D4H/D4H2 is `{id, t, a}`. Sending the wrong key runs the feed and dispenses
+// nothing (`err_code 8`), so the control is bound to whichever the model reads.
 function renderFeedEditor(id, t, value) {
   const groups = Array.isArray(value.schedule) ? value.schedule : [];
   const dat = ` data-id="${esc(id)}" data-target="${esc(t.target)}"`;
@@ -192,8 +194,8 @@ function renderFeedEditor(id, t, value) {
                 (meal, mi) => `<div class="sched-row">
         <span class="sched-vals">
           <input type="time" value="${esc(secToClock(meal.t))}" data-change="sched-meal-time"${dat} data-path="${esc(gi)}" data-idx="${esc(mi)}">
-          <label class="sw-inline"><span>${t.dual ? 'Hopper 1' : 'Portions'}</span>
-            <input type="number" class="sched-portion" min="0" max="255" step="1" value="${esc(meal.a1 ?? 0)}" data-change="sched-meal-a1"${dat} data-path="${esc(gi)}" data-idx="${esc(mi)}"></label>
+          <label class="sw-inline"><span>${t.dual ? 'Hopper 1' : 'Amount'}</span>
+            <input type="number" class="sched-portion" min="0" max="255" step="1" value="${esc(t.dual ? (meal.a1 ?? 0) : (meal.a ?? meal.a1 ?? 0))}" data-change="${t.dual ? 'sched-meal-a1' : 'sched-meal-a'}"${dat} data-path="${esc(gi)}" data-idx="${esc(mi)}"></label>
           ${
             t.dual
               ? `<label class="sw-inline"><span>Hopper 2</span>
@@ -430,6 +432,21 @@ onAction('sched-add-point', el =>
 // --- feeder meals -----------------------------------------------------------
 const feedGroup = (v, path) => v.schedule[Number(path)];
 
+// Whether this feeder's meals carry two hopper amounts (`a1`/`a2`) or one
+// (`a`). The server decides it, next to the set that answers the same question
+// for feed_realtime (defaults.schedule_targets, utils/const.py).
+const feedIsDual = (id, target) => {
+  const d = DEV_DETAIL.get(Number(id));
+  const t = ((d && d.schedules) || []).find(s => s.target === target);
+  return !!(t && t.dual);
+};
+
+// A new single-hopper meal's default `a`. 10 is what the single-hopper path
+// sends for a manual feed (ha/commands.py::SINGLE_HOPPER_AMOUNT) — the device's
+// own unit, divided by a config constant, NOT portions; a D4H2 cloud schedule
+// was captured dispensing at `a: 20`. The owner sets the real size.
+const SINGLE_MEAL_AMOUNT = 10;
+
 onAction('sched-add-feed-group', el =>
   schedEdit(el.dataset.id, el.dataset.target, v => {
     if (!Array.isArray(v.schedule)) v.schedule = [];
@@ -452,7 +469,11 @@ onAction('sched-add-meal', el =>
         (max, g) => (g.it || []).reduce((m, meal) => Math.max(m, Number(meal.id) || 0), max),
         0,
       ) + 1;
-    group.it.push({ id: next, t: 0, a1: 1, a2: 0 });
+    // The amount key must match the model, or the feed dispenses nothing.
+    const amount = feedIsDual(el.dataset.id, el.dataset.target)
+      ? { a1: 1, a2: 0 }
+      : { a: SINGLE_MEAL_AMOUNT };
+    group.it.push({ id: next, t: 0, ...amount });
   }),
 );
 onAction('sched-drop-meal', el =>
@@ -474,6 +495,7 @@ const mealAmount = (el, field) =>
   });
 onChange('sched-meal-a1', el => mealAmount(el, 'a1'));
 onChange('sched-meal-a2', el => mealAmount(el, 'a2'));
+onChange('sched-meal-a', el => mealAmount(el, 'a'));
 
 onAction('sched-revert', el => {
   SCHEDULE_EDITS.delete(schedKey(Number(el.dataset.id), el.dataset.target));

--- a/addon/tests/test_feed_get.py
+++ b/addon/tests/test_feed_get.py
@@ -10,6 +10,7 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from petkit_local.devices.registry import DeviceRegistry
 from petkit_local.http.handlers.feed import (
+    _amount_fields,
     _build_latest,
     _compute_next_tick,
     migrate_minute_schedule,
@@ -98,6 +99,80 @@ def test_todays_own_passed_meal_is_excluded(warsaw_tz):
         {"re": "4", "it": [{"id": "n_60540", "t": 60540, "a1": 1, "a2": 0}]},
     ], "v": 2}
     assert _build_latest(feed, CAPTURE_TS) == []
+
+
+# --- single-hopper (D4H/D4H2) amount shape ----------------------------------
+# A single-hopper feeder's meal carries one `a`, not the Dual-Hopper's a1/a2.
+# The firmware fires from latest[], so latest must repeat `a`: a D4H handed
+# a1/a2 runs the feed cycle and dispenses nothing (real_amount 0, err_code 8 —
+# codes.FEED_RESULT[8], the mirror of the Dual-Hopper's issue #2).
+
+def test_amount_fields_preserves_the_model_shape():
+    assert _amount_fields({"a": 20}) == {"a": 20}
+    assert _amount_fields({"a1": 1, "a2": 6}) == {"a1": 1, "a2": 6}
+    assert _amount_fields({}) == {"a1": 0, "a2": 0}
+    # `a` is the single-hopper key and wins when a payload carries both.
+    assert _amount_fields({"a": 5, "a1": 9, "a2": 9}) == {"a": 5}
+
+
+def test_single_hopper_meal_carries_a_into_latest():
+    """The D4H2 bug: a meal with only `a` must reach latest[] as `a`, never
+    downgraded to a1/a2. This is the deterministic form of the live check —
+    'does latest now carry a:20 at fire time'."""
+    now = time.time()
+    lt = time.localtime(now)
+    secs = lt.tm_hour * 3600 + lt.tm_min * 60 + lt.tm_sec
+    future_t = (secs + 7200) % 86400
+    feed = {"schedule": [{"re": "1,2,3,4,5,6,7", "it": [
+        {"id": f"n_{future_t}", "t": future_t, "a": 20},
+    ]}], "v": 2}
+    latest = _build_latest(feed, now)
+    assert latest, "an all-week meal 2h out must appear"
+    assert all(e["a"] == 20 and "a1" not in e and "a2" not in e for e in latest)
+    assert latest[0]["id"].startswith("s_")
+    assert 7100 < latest[0]["t"] < 7300
+
+
+def test_single_hopper_deferred_carries_a():
+    now = time.time()
+    feed = {
+        "schedule": [{"re": "1,2,3,4,5,6,7", "it": []}],
+        "deferred": [{"id": "d_20260819_43200", "a": 20, "fire_at": now + 3600}],
+        "v": 2,
+    }
+    d_entries = [e for e in _build_latest(feed, now) if e["id"].startswith("d_")]
+    assert len(d_entries) == 1
+    assert d_entries[0]["a"] == 20
+    assert "a1" not in d_entries[0] and "a2" not in d_entries[0]
+
+
+async def test_http_serves_single_hopper_a_end_to_end():
+    """What a D4H2 receives on its dev_feed_get poll: schedule[].it[] keeps `a`,
+    itemJsonString echoes it, and the recomputed latest[] carries `a` — the
+    thing that was zeroed to a1/a2 and made the feed dispense nothing."""
+    app, reg = _app(device_type="d4h")
+    d = reg.get(1)
+    now = time.time()
+    lt = time.localtime(now)
+    secs = lt.tm_hour * 3600 + lt.tm_min * 60 + lt.tm_sec
+    future_t = (secs + 7200) % 86400
+    d.config["feed_schedule"] = {
+        "schedule": [{"re": "1,2,3,4,5,6,7", "it": [
+            {"id": f"n_{future_t}", "t": future_t, "a": 20},
+        ]}],
+        "v": 2,
+    }
+    async with TestClient(TestServer(app)) as c:
+        r = await c.get(
+            "/6/d4h/dev_feed_get",
+            headers={"X-Device": "id=1&nonce=x&timestamp=1&type=d4h&sign=x"})
+        result = (await r.json())["result"]
+        meal = result["schedule"][0]["it"][0]
+        assert meal == {"id": f"n_{future_t}", "t": future_t, "a": 20}
+        assert result["schedule"][0]["itemJsonString"] == \
+            f'[{{"a":20,"id":"n_{future_t}","t":{future_t}}}]'
+        assert result["latest"]
+        assert all(e["a"] == 20 and "a1" not in e for e in result["latest"])
 
 
 # --- serve-time behaviour ----------------------------------------------------

--- a/addon/tests/test_schedules.py
+++ b/addon/tests/test_schedules.py
@@ -9,6 +9,7 @@ times, told apart only by `type`, so an editor that rewrites its own section has
 to keep the other one.
 """
 import json
+import time
 
 import pytest
 
@@ -525,6 +526,87 @@ async def test_a_feeding_schedule_keeps_the_devices_own_bookkeeping():
 ])
 async def test_a_malformed_feeding_schedule_is_refused(bad):
     app, reg, bridge = _panel("d4sh")
+    c = await _client(app)
+    try:
+        status, _ = await _save(c, "feed_schedule", bad)
+        assert status == 400
+        assert "feed_schedule" not in reg.get(1).config
+    finally:
+        await c.close()
+
+
+# --- the single-hopper feeder (D4H/D4H2) ------------------------------------
+# A single hopper's `pk_schmg_parse_schedule` reads one `a` per meal, not the
+# Dual-Hopper's a1/a2 (events/codes.py::FEED_SCHEDULE_ITEM_KEYS). Sent a1/a2 it
+# runs the feed and dispenses nothing (err_code 8). So on a D4H the stored meal,
+# the itemJsonString and the pushed latest must all carry `a`.
+
+async def test_a_single_hopper_schedule_is_stored_and_pushed_with_a():
+    app, reg, bridge = _panel("d4h")
+    c = await _client(app)
+    try:
+        now = time.time()
+        lt = time.localtime(now)
+        secs = lt.tm_hour * 3600 + lt.tm_min * 60 + lt.tm_sec
+        future_t = (secs + 7200) % 86400
+        status, _ = await _save(c, "feed_schedule", {"schedule": [
+            {"re": "1,2,3,4,5,6,7", "it": [{"id": 1, "t": future_t, "a": 20}]},
+        ]})
+        assert status == 200
+
+        group = reg.get(1).config["feed_schedule"]["schedule"][0]
+        assert sorted(group["it"][0]) == ["a", "id", "t"]
+        assert group["it"][0]["a"] == 20
+        assert json.loads(group["itemJsonString"]) == group["it"]
+        assert '"a":20' in group["itemJsonString"]
+
+        _did, suffix, envelope = bridge.sent[0]
+        assert suffix == "property/set"
+        wire = json.loads(envelope["params"]["feed"])
+        assert wire["latest"]
+        assert all(e["a"] == 20 and "a1" not in e for e in wire["latest"])
+    finally:
+        await c.close()
+
+
+async def test_a_single_hopper_meal_migrates_a_legacy_a1_to_a():
+    """A schedule the dual-only editor saved carries a1; on a single hopper it
+    is read as `a` rather than silently emptied — but never the other way."""
+    app, reg, bridge = _panel("d4h")
+    c = await _client(app)
+    try:
+        status, _ = await _save(c, "feed_schedule", {"schedule": [
+            {"re": "1", "it": [{"id": 1, "t": 510, "a1": 3}]},
+        ]})
+        assert status == 200
+        meal = reg.get(1).config["feed_schedule"]["schedule"][0]["it"][0]
+        assert meal == {"id": "n_510", "t": 510, "a": 3}
+    finally:
+        await c.close()
+
+
+async def test_a_single_hopper_deferred_feed_stores_a():
+    app, reg, bridge = _panel("d4h")
+    c = await _client(app)
+    try:
+        r = await c.post("/api/devices/1/deferred-feed",
+                         data=json.dumps({"date": "2099-06-01", "time": "12:00", "a": 20}))
+        assert r.status == 200
+        out = await r.json()
+        assert out["feed"]["a"] == 20 and "a1" not in out["feed"]
+        stored = reg.get(1).config["feed_schedule"]["deferred"][0]
+        assert stored["a"] == 20 and "a1" not in stored
+    finally:
+        await c.close()
+
+
+@pytest.mark.parametrize("bad", [
+    {"schedule": [{"re": "1", "it": [{"id": 1, "t": 60, "a": 256}]}]},  # wraps a byte
+    {"schedule": [{"re": "1", "it": [{"id": 1, "t": 60, "a": -1}]}]},
+    {"schedule": [{"re": "1", "it": [{"id": 1, "t": 60}]}]},            # no amount at all
+])
+async def test_a_malformed_single_hopper_schedule_is_refused(bad):
+    app, reg, bridge = _panel("d4h")
     c = await _client(app)
     try:
         status, _ = await _save(c, "feed_schedule", bad)


### PR DESCRIPTION
## What

The single-hopper D4H/D4H2 reads a lone `a` per scheduled meal, where the Dual-Hopper (D4SH) reads `a1`/`a2` (`pk_schmg_parse_schedule`). Handed `a1`/`a2`, a single hopper runs the whole feed cycle and dispenses nothing — `real_amount: 0, err_code: 8` (FEED_RESULT[8], "failed (nothing dispensed)") — the mirror of the Dual-Hopper's issue #2.

This selects the amount key by model everywhere a meal is built:

- `events/codes.py` — `FEED_SCHEDULE_ITEM_KEYS` gains `a`
- `http/handlers/feed.py` — `latest[]` (what the firmware actually fires from) carries the source meal's own key
- `web/api/schedules.py` — the schedule cleaner and the deferred-feed endpoint validate/store `a` for a single hopper, `a1`/`a2` for a dual
- `web/static/js/schedules.js` — the panel editor shows one **Amount** field bound to `a`

A legacy `a1` saved by the old dual-only editor is read as `a` on a single hopper, so an existing schedule still feeds; the two never convert the other way.

## Testing

Tested on a **YumShare Solo (single-hopper, with camera)** — a cloud-made schedule now dispenses (`err_code: 0`). **Not tested on a Dual-Hopper (D4SH)**; that path is refactored but behaviourally unchanged and unverified on hardware here.

`pytest tests/test_feed_get.py tests/test_schedules.py` → 66 passed; `ruff` and `prettier` clean.

## Note: the single-hopper amount is ~10× the portions

For some reason the single-hopper `a` needs to be ~10× the number of portions to dispense — it is the device's own unit (divided by a config constant), **not** the portion count. A D4H2 cloud schedule was captured putting out 2 portions at `a: 20`, so the editor defaults a new meal to `a: 10` (≈1 portion) and the owner sets the real size. This 10× factor is unconfirmed beyond that single capture.
