### PR TITLE
Serve dev_state_report `time` at the device's own UTC offset

### DIFF
--- a/addon/petkit_local/http/handlers/state_report.py
+++ b/addon/petkit_local/http/handlers/state_report.py
@@ -150,6 +150,12 @@ async def handle_state_report(request: web.Request) -> web.Response:
             # visible regression. Events carry a state snapshot of their own,
             # so the cloud can afford to be quiet and we cannot.
             "interval": 30,
-            "time": cloud_timestamp(),
+            # LOCAL time with the device's own offset, not UTC: the firmware
+            # takes its timezone from this field and sets the RTC its scheduled
+            # feeds fire against, so `+0000` here fires every meal two hours late
+            # on a UTC+2 box (cloud_timestamp). An unidentified device (no offset
+            # to speak for) falls back to UTC.
+            "time": cloud_timestamp(
+                offset_hours=device.timezone_offset if device else None),
         }
     })

--- a/addon/petkit_local/utils/timeutil.py
+++ b/addon/petkit_local/utils/timeutil.py
@@ -27,16 +27,32 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 DATE_FORMAT = "%Y-%m-%d"
 
 
-def cloud_timestamp(when: float | None = None) -> str:
-    """A UTC instant in the format PetKit's cloud puts on the wire.
+def cloud_timestamp(when: float | None = None,
+                    offset_hours: float | None = None) -> str:
+    """An instant in the format PetKit's cloud puts on the wire, at an offset.
 
-    `2026-07-15T05:19:42.000+0000` — milliseconds, and a `+0000` offset with no
-    colon. NOT `datetime.isoformat()`, which produces `+00:00` and would be a
-    different string to whatever parses it on the device. Confirmed against
-    captured `dev_state_report` and `dev_schedule_get` replies.
+    `2026-08-19T15:45:51.170+0200` — milliseconds, and a `+HHMM` offset with no
+    colon. NOT `datetime.isoformat()`, which produces `+02:00` and would be a
+    different string to whatever parses it on the device.
+
+    `offset_hours` is the UTC offset to render the instant AT — the device's own
+    (`Device.timezone_offset`). It is NOT cosmetic. `dev_state_report`'s reply is
+    where the firmware reads its timezone: it parses this `time`, extracts the
+    offset (`get_ctime_timezone`) and sets its RTC from it, and its scheduled
+    feeds fire against that RTC. Confirmed on a live D4H2 — the real cloud
+    answered `+0200` and a meal fired on the wall-clock minute, while our own
+    `+0000` set the box to UTC and fired every meal two hours late. The stored
+    epoch is still UTC (this codebase changes nothing there); only the wire
+    string is localized. Rounded to whole minutes so the offset is always the
+    `+HHMM` the device reads, never a sub-minute `%z` variant.
+
+    Omitted (or None) keeps the historical UTC/`+0000`, for a caller with no
+    device to speak for — an unidentified device is the only one left.
     """
-    now = datetime.fromtimestamp(when, timezone.utc) if when is not None \
-        else datetime.now(timezone.utc)
+    tz = timezone.utc if offset_hours is None \
+        else timezone(timedelta(minutes=round(offset_hours * 60)))
+    now = datetime.fromtimestamp(when, tz) if when is not None \
+        else datetime.now(tz)
     return (now.strftime("%Y-%m-%dT%H:%M:%S.")
             + f"{now.microsecond // 1000:03d}"
             + now.strftime("%z"))

--- a/addon/tests/test_http.py
+++ b/addon/tests/test_http.py
@@ -91,6 +91,37 @@ async def test_full_boot_sequence():
         await client.close()
 
 
+async def test_state_report_time_carries_the_devices_offset():
+    """`dev_state_report`'s `time` is where the firmware reads its timezone and
+    sets the RTC its scheduled feeds fire against. A UTC `+0000` here on a
+    UTC+2 box fires every meal two hours late, so the device's own offset — a
+    +5.5 override here — must be stamped on the wire, not UTC."""
+    reg = DeviceRegistry()
+    client = await _client(reg)
+    try:
+        await client.post("/6/t5/dev_signup", headers=HDR)
+        reg.get(100).config["timezone"] = 5.5  # override wins in timezone_offset
+        r = await client.post("/6/t5/dev_state_report", headers=HDR,
+                              data=json.dumps({"workState": 1}))
+        t = (await r.json())["result"]["time"]
+        assert t.endswith("+0530"), t
+    finally:
+        await client.close()
+
+
+async def test_state_report_time_is_utc_for_an_unidentified_device():
+    """No Device to speak an offset for -> the historical UTC `+0000`, never a
+    guess. The `/{path:.*}` catch-all still answers, so this must not raise."""
+    reg = DeviceRegistry()
+    client = await _client(reg)
+    try:
+        r = await client.post("/6/t5/dev_state_report", headers=HDR,
+                              data=json.dumps({"workState": 1}))
+        assert (await r.json())["result"]["time"].endswith("+0000")
+    finally:
+        await client.close()
+
+
 # --- a device that puts its identity in the body ----------------------------
 #
 # The Ingenic models send `X-Device: id=...&sn=...` on every request. An ESP32

--- a/addon/tests/test_timeutil.py
+++ b/addon/tests/test_timeutil.py
@@ -12,7 +12,7 @@ import time
 import pytest
 
 from petkit_local.utils.timeutil import (
-    local_day_bounds, local_day_start, local_offset_hours,
+    cloud_timestamp, local_day_bounds, local_day_start, local_offset_hours,
     offset_hours_for_locale, parse_date,
 )
 
@@ -145,3 +145,31 @@ def test_unusable_locale_returns_none_for_fallback(bad):
     caller drops to the numeric sources. `UTC` has no slash and is handled by
     the numeric path's 0.0 anyway."""
     assert offset_hours_for_locale(bad, _SUMMER) is None
+
+
+def test_cloud_timestamp_defaults_to_utc():
+    """No offset given -> the historical UTC/`+0000`, for an unidentified
+    device we cannot speak an offset for. `_SUMMER` is UTC midnight."""
+    assert cloud_timestamp(_SUMMER) == "2026-07-26T00:00:00.000+0000"
+
+
+def test_cloud_timestamp_localizes_to_the_offset():
+    """UTC midnight is 02:00 at +2, and the offset is stamped `+0200`.
+
+    This is the `dev_state_report` `time` field the firmware reads to set its
+    RTC: served `+0000` on a UTC+2 box it fires every scheduled meal two hours
+    late, so the wall-clock must really move, not just the suffix be relabelled.
+    """
+    assert cloud_timestamp(_SUMMER, offset_hours=2.0) == "2026-07-26T02:00:00.000+0200"
+
+
+@pytest.mark.parametrize("offset,suffix", [
+    (0.0, "+0000"),
+    (-7.0, "-0700"),      # west of UTC (PDT)
+    (5.75, "+0545"),      # quarter-hour zone -> whole-minute +HHMM, never sub-minute
+    (5.5, "+0530"),       # half-hour zone
+    (14.0, "+1400"),      # the far end of api_timezone's valid range
+])
+def test_cloud_timestamp_offset_is_hhmm(offset, suffix):
+    """`+HHMM`, no colon and no seconds -- the shape the firmware parses."""
+    assert cloud_timestamp(_SUMMER, offset_hours=offset).endswith(suffix)


### PR DESCRIPTION
## Problem

Scheduled feeds fire at the wrong wall-clock time — two hours late on a UTC+2 install.

The device does not schedule off `dev_syncTime` (that's a raw UTC epoch, and correct). It takes its timezone from **`dev_state_report`'s `time` field**: the firmware parses the ISO offset (`get_ctime_timezone`), sets its RTC from it, and its scheduled meals fire against that RTC. `cloud_timestamp()` hardcoded UTC `+0000`, so a box in Europe/Budapest set its clock to UTC and fired every scheduled meal two hours late.

The numeric `timezone` in `dev_signup` / `dev_device_info` was already correct (`Device.timezone_offset`, e.g. `2.0` from the reported locale), but the firmware does not set its clock from that field — only from the `time` offset here (and from a `property.set{timezone}` string, which is why setting the timezone manually in the panel worked around it).

## Fix

Render the `dev_state_report` `time` at the device's own `timezone_offset` — the same value already sent at signup — instead of UTC:

- `cloud_timestamp()` gains an `offset_hours` argument; the instant is rendered at that offset, rounded to whole minutes so the wire string is always the `+HHMM` the device parses (never a sub-minute `%z` variant). Omitted → the historical UTC `+0000`, for an unidentified device with no offset to speak for.
- `handle_state_report` passes `device.timezone_offset` (and `None`, i.e. UTC, when the device is unidentified).

The stored epoch stays UTC — this changes only the wire string.

## Evidence

Confirmed on a live **D4H2** through proxy mode: the real cloud answered `time: "...+0200"`, the device logged `get state res timzone = 2.00`, set its RTC, and the scheduled meal fired on the wall-clock minute. Our local server answered `+0000` and fired the same meal two hours late.

## Testing

`pytest tests/test_timeutil.py tests/test_http.py` — new coverage for the offset rendering (`+0200`, `-0700`, quarter/half-hour zones → whole-minute `+HHMM`), the localized wall-clock, and the state-report reply carrying the device's offset (and UTC for an unidentified device). Full suite: 1706 passed, 1 skipped; `ruff` clean.
