### PR TITLE
Fix feeder weekday selector and time-field editing in the schedule editor

### DIFF
--- a/addon/petkit_local/web/static/js/schedules.js
+++ b/addon/petkit_local/web/static/js/schedules.js
@@ -373,7 +373,12 @@ const entryListOf = v => (Array.isArray(v) ? v : v.schedule);
 onChange('sched-day', el =>
   schedEdit(el.dataset.id, el.dataset.target, v => {
     const entry = entryListOf(v)[Number(el.dataset.idx)];
-    const field = 'rpt' in entry ? 'rpt' : 'repeats';
+    // The day set has three spellings and this bar renders all of them: a feeder
+    // group's `re`, a weekly entry's `rpt`, a cleaning point's `repeats`. Write
+    // back the one THIS entry actually carries — resolving `re` last put every
+    // feeder click on a stray `repeats` the device never reads, so the weekdays
+    // repainted straight back from the untouched `re`.
+    const field = 're' in entry ? 're' : 'rpt' in entry ? 'rpt' : 'repeats';
     const days = new Set(
       String(entry[field] || '')
         .split(',')

--- a/addon/petkit_local/web/static/js/schedules.js
+++ b/addon/petkit_local/web/static/js/schedules.js
@@ -76,14 +76,31 @@ function schedValue(id, t) {
   return JSON.parse(JSON.stringify(t.value ?? (t.kind === 'feed' ? { schedule: [] } : [])));
 }
 
-function schedEdit(id, target, fn) {
+function schedEdit(id, target, fn, repaint = true) {
   const d = DEV_DETAIL.get(Number(id));
   const t = (d.schedules || []).find(s => s.target === target);
   if (!t) return;
   const value = schedValue(Number(id), t);
   const next = fn(value);
   SCHEDULE_EDITS.set(schedKey(Number(id), target), next === undefined ? value : next);
-  repaintSchedules(Number(id));
+  if (repaint) repaintSchedules(Number(id));
+}
+
+// A value typed into a text or number field: store the edit and reveal Save
+// WITHOUT repainting. Re-rendering the card would replace the very <input> being
+// typed in, and an <input type="time"> commits `01:00` the instant its hour
+// segment reads `1` (the minute is already `00`), firing `change` mid-entry --
+// so a repaint there steals focus before the second digit and the meal lands an
+// hour early. The dirty class and toolbar are added in place instead; the next
+// full repaint renders the identical thing from SCHEDULE_EDITS.
+function schedEditLive(el, fn) {
+  schedEdit(el.dataset.id, el.dataset.target, fn, false);
+  const sched = el.closest('.sched');
+  if (!sched || sched.classList.contains('dirty')) return;
+  sched.classList.add('dirty');
+  const head = sched.querySelector('.sched-head');
+  if (head && !head.querySelector('.sched-actions'))
+    head.insertAdjacentHTML('beforeend', schedActions(el.dataset.id, el.dataset.target));
 }
 
 function repaintSchedules(id) {
@@ -262,6 +279,14 @@ function renderPointsEditor(id, t, value) {
     .join('');
 }
 
+// A dirty schedule's Save/Discard pair. Also injected in place by schedEditLive
+// when a text field is edited, so it is a function rather than inline markup.
+function schedActions(id, target) {
+  const dat = ` data-id="${esc(id)}" data-target="${esc(target)}"`;
+  return `<span class="sched-actions"><button class="act"${dat} data-action="sched-save">Save</button>
+    <button class="link"${dat} data-action="sched-revert">Discard</button></span>`;
+}
+
 function renderSchedules(d, sectionEntities) {
   const targets = d.schedules || [];
   const all = sectionEntities || [];
@@ -284,15 +309,9 @@ function renderSchedules(d, sectionEntities) {
       // Save appears only once there is something to save. Five permanent Save
       // buttons in one card read as five things demanding attention; a button
       // that shows up when you have changed something reads as one.
-      const dat = ` data-id="${esc(d.id)}" data-target="${esc(t.target)}"`;
       return `<div class="sched${dirty ? ' dirty' : ''}">
       <div class="sched-head"><span class="sched-name">${esc(t.name)}</span>
-        ${
-          dirty
-            ? `<span class="sched-actions"><button class="act"${dat} data-action="sched-save">Save</button>
-               <button class="link"${dat} data-action="sched-revert">Discard</button></span>`
-            : ''
-        }</div>
+        ${dirty ? schedActions(d.id, t.target) : ''}</div>
       ${body}</div>`;
     })
     .join('');
@@ -333,13 +352,13 @@ onSection('schedules', renderSchedules);
 const rangeListOf = (value, path) => (path === '' ? value : value[Number(path)].time);
 
 onChange('sched-from', el =>
-  schedEdit(el.dataset.id, el.dataset.target, v => {
+  schedEditLive(el, v => {
     const m = clockToMin(el.value);
     if (m !== null) rangeListOf(v, el.dataset.path)[Number(el.dataset.idx)][0] = m;
   }),
 );
 onChange('sched-to', el =>
-  schedEdit(el.dataset.id, el.dataset.target, v => {
+  schedEditLive(el, v => {
     const m = clockToMin(el.value);
     if (m !== null) rangeListOf(v, el.dataset.path)[Number(el.dataset.idx)][1] = m;
   }),
@@ -407,7 +426,7 @@ onAction('sched-drop-weekly', el =>
   }),
 );
 onChange('sched-point-time', el =>
-  schedEdit(el.dataset.id, el.dataset.target, v => {
+  schedEditLive(el, v => {
     const m = clockToMin(el.value);
     if (m !== null) v[Number(el.dataset.idx)].time = m;
   }),
@@ -466,13 +485,13 @@ onAction('sched-drop-meal', el =>
   }),
 );
 onChange('sched-meal-time', el =>
-  schedEdit(el.dataset.id, el.dataset.target, v => {
+  schedEditLive(el, v => {
     const s = clockToSec(el.value);
     if (s !== null) feedGroup(v, el.dataset.path).it[Number(el.dataset.idx)].t = s;
   }),
 );
 const mealAmount = (el, field) =>
-  schedEdit(el.dataset.id, el.dataset.target, v => {
+  schedEditLive(el, v => {
     const n = Number(el.value);
     if (Number.isInteger(n) && n >= 0 && n <= 255)
       feedGroup(v, el.dataset.path).it[Number(el.dataset.idx)][field] = n;


### PR DESCRIPTION
Two independent bugs in the schedule editor, one commit each.

## 1. Feeder weekday selector wrote to a key the device never reads

The weekday bar renders a schedule's day set from whichever key the shape uses — a feeder group's `re`, a weekly entry's `rpt`, a cleaning point's `repeats`. The click handler, though, resolved only `'rpt' in entry ? 'rpt' : 'repeats'`.

A feeder group has neither `rpt` nor `repeats`, so every day toggle wrote a **stray `repeats`** the firmware never reads and left `re` untouched. The repaint then drew the days straight back from the unchanged `re`, so the selector looked read-only: days displayed correctly, clicking did nothing visible, and the saved schedule never changed.

Fix: resolve `re` first — `'re' in entry ? 're' : 'rpt' in entry ? 'rpt' : 'repeats'`. Weekly and points entries have no `re`, so their resolution is unchanged; single- and dual-hopper feeders both key the day set on `re` (the hopper split lives in each meal's `a1`/`a2`, handled elsewhere), so both are fixed equally.

## 2. Editor repainted under a half-typed time field

Every value edit ran through `schedEdit`, which repaints the whole card by replacing its `outerHTML`. An `<input type="time">` whose minute is already `00` commits a complete value the instant its hour segment reads a single digit — so typing the first digit of a two-digit hour fired `change` → repaint → the input was torn down before the second digit could be typed. Focus was stolen and the wrong time stored: `12` became `01`. This hit every time field in the editor (from/to ranges, cleaning/deodorizing points, feeder meal times) and the meal amount fields.

Fix: route text and number edits through a new `schedEditLive`, which stores the edit and reveals the Save/Discard toolbar **in place** (adding the `dirty` class and injecting the toolbar) without a repaint, leaving the focused input intact. Checkbox and structural edits still repaint — they carry no caret to lose, and the weekday highlight/label state is driven from the model on redraw. The next full repaint (background refresh, or a structural edit) renders the identical result from the stored edits.

## Testing

Frontend-only; verified by hand in the panel against a D4H feeder schedule (weekday toggles now persist to `re`; two-digit hours type without jumping) and against a litter-box ranges/points schedule (weekly `rpt` and point `repeats` still toggle; times type cleanly). `prettier` clean.
